### PR TITLE
Clarify checkout metadata and conversion ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The open standard for AI agent affiliate attribution.
 
-AAP defines how AI agents discover offers, record recommendations, and earn commission when those recommendations lead to purchases — without cookies, tracking pixels, or browser sessions.
+AAP defines how AI agents discover offers, record recommendations, and preserve attribution when those recommendations lead to eligible conversions — without cookies, tracking pixels, or browser sessions.
 
 ## Documents
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AAP defines how AI agents discover offers, record recommendations, and earn comm
 | [AAP Code](./spec/v1/aap-code.md) | The signed attribution token — the core primitive |
 | [Attribution Model](./spec/v1/attribution.md) | How attribution works — binary + fallback chain |
 | [Commission Model](./spec/v1/commission.md) | Commission types, floors, and settlement |
+| [Conversion Ledger](./spec/v1/conversion-ledger.md) | Checkout metadata, conversion lifecycle, and settlement fields |
 | [API Reference](./spec/v1/api.md) | REST API endpoints |
 | [MCP Integration](./spec/v1/mcp.md) | Using AAP as an MCP tool |
 | [Security](./spec/v1/security.md) | Cryptographic signing, fraud prevention, trust model |

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -46,7 +46,7 @@ A bounded interaction between an agent and the AAP API. Created when an agent se
 An attribution event. When an agent calls `recommend()`, it records who recommended what, when, why, and where. This is the equivalent of a "click" in traditional affiliate marketing.
 
 ### Conversion
-A completed transaction. When a user purchases a recommended product, the merchant reports the conversion. AAP matches it to the original recommendation.
+A completed transaction or approved commercial outcome. When a user purchases, applies, activates, or otherwise completes the merchant-defined conversion event for a recommended product, the merchant or payment evidence source reports the conversion. AAP matches it to the original recommendation and records it in the conversion ledger.
 
 ### Commission
 The payment from merchant to agent builder for driving a sale. Calculated based on merchant-defined terms, minus the 20% network fee.
@@ -66,9 +66,9 @@ The payment from merchant to agent builder for driving a sale. Calculated based 
                Agent calls checkout() → transaction initiated
                AAP routes to merchant checkout
 
-4. CONVERT     Merchant confirms the sale
-               Merchant calls conversions API with order details
-               AAP matches conversion to recommendation
+4. CONVERT     Merchant or payment evidence source confirms the outcome
+               Conversion evidence includes checkout attribution metadata
+               AAP matches conversion to recommendation and records ledger entry
 
 5. SETTLE      Validation period passes (no cancellation)
                Commission calculated: merchant terms minus 20% network fee
@@ -118,6 +118,7 @@ CREATED → ACTIVE → CHECKOUT → CONVERTED → VALIDATED → SETTLED
 - **[AAP Code](./aap-code.md)** — Signed attribution token format and verification
 - **[Attribution Model](./attribution.md)** — Binary attribution + fallback chain
 - **[Commission Model](./commission.md)** — Types, floors, calculation, settlement
+- **[Conversion Ledger](./conversion-ledger.md)** — Checkout metadata, conversion lifecycle, and settlement fields
 - **[API Reference](./api.md)** — REST endpoints
 - **[MCP Integration](./mcp.md)** — MCP tool definitions
 - **[Payment Architecture](./payments.md)** — Payment modes, verification, Hyperswitch integration

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -20,7 +20,7 @@ AAP is an open spec with a centralised trust model. The specification is public 
 Businesses that sell products or services. They publish offers into the AAP registry and pay commission when agent-driven recommendations lead to sales.
 
 ### Agent Builders
-Developers who build AI agents. They integrate the AAP SDK so their agents can discover offers, make recommendations, and earn commission.
+Developers who build AI agents. They integrate the AAP SDK so their agents can discover offers, make recommendations, and preserve attribution for eligible conversions.
 
 ### Agents
 AI systems (Claude, ChatGPT, custom agents) that recommend products to users on behalf of their builders.
@@ -29,7 +29,7 @@ AI systems (Claude, ChatGPT, custom agents) that recommend products to users on 
 The entity that operates the AAP infrastructure:
 - Issues and signs AAP Codes
 - Operates the offer registry
-- Verifies merchants and agents
+- Registers merchants and agents
 - Matches recommendations to conversions
 - Calculates and settles commission
 - Provides fraud detection

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -120,7 +120,7 @@ CREATED → ACTIVE → CHECKOUT → CONVERTED → VALIDATED → SETTLED
 - **[Commission Model](./commission.md)** — Types, floors, calculation, settlement
 - **[API Reference](./api.md)** — REST endpoints
 - **[MCP Integration](./mcp.md)** — MCP tool definitions
-- **[Payment Architecture](./payments.md)** — Payment modes, verification, Hyperswitch integration
+- **[Payment Architecture](./payments.md)** — Payment modes, verification requirements, and payment orchestration
 - **[Security](./security.md)** — Signing, fraud prevention, trust model
 
 ## 8. Versioning

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -40,28 +40,31 @@ aap://rako.sh/v1/eyJ2IjoiMSIsImlzcyI6InJha28uc2giLCJvZmYiOiIwMUpRWEsxMDAxU01BUlR
 
 ---
 
-## Payment Metadata Embedding
+## Checkout Metadata Embedding
 
-When a purchase is initiated through AAP, the AAP Code is embedded in payment metadata by the AAP platform via Hyperswitch. Agents do **not** manually embed AAP Codes in order notes or descriptions.
+When checkout is initiated through AAP, the AAP Code is carried in checkout attribution metadata by the AAP platform or certified merchant integration. In payment-orchestrated flows this metadata may be stored on a payment object via Hyperswitch. Agents do **not** manually embed AAP Codes in order notes or descriptions.
 
 ### How It Works
 
-1. Agent calls `POST /v1/purchase` with a `recommendationId`.
-2. AAP creates a payment link/intent on the merchant's PSP via Hyperswitch.
-3. AAP sets the following metadata on the payment object:
+1. Agent calls `POST /v1/checkout` with a `recommendationId`.
+2. AAP creates or records a checkout attempt for the merchant flow.
+3. AAP or the certified merchant integration sets the following metadata on the checkout, payment, order, application, or equivalent durable transaction object:
 
 ```json
 {
   "metadata": {
     "aap_code": "aap://rako.sh/v1/{base64url_payload}.{base64url_signature}",
-    "aap_recommendation_id": "01JQXK1001SMARTY1GB000001",
-    "aap_session_id": "sess_abc123"
+    "aap_recommendation_id": "01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
+    "aap_session_id": "sess_abc123",
+    "aap_offer_id": "01JQXK1001SMARTY1GB000001",
+    "aap_merchant_id": "01JQXK0001SMARTY000000001",
+    "aap_checkout_id": "01KN6KWQEENKX01N1TZE3R1TPX"
   }
 }
 ```
 
-4. The merchant's PSP stores this metadata alongside the payment record.
-5. On payment completion, the PSP webhook delivers the metadata back to AAP.
+4. The merchant or payment system stores this metadata alongside the transaction record.
+5. On conversion, the merchant, payment source, or reconciliation process delivers the metadata or a durable reference back to AAP.
 6. AAP verifies the `aap_code` signature and matches it to the recommendation.
 
 ### Why Platform-Side Embedding
@@ -69,10 +72,10 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 | Approach | Problem |
 |----------|----------|
 | Agent embeds AAP Code in order notes | Agent can forge or omit codes |
-| Merchant embeds AAP Code at checkout | Merchant can strip codes to avoid commission |
-| **AAP embeds via Hyperswitch** | **Tamper-proof — neither agent nor merchant controls metadata** |
+| Merchant stores only an unaudited free-text note | Metadata can be stripped or altered without evidence |
+| **AAP or certified integration stores structured metadata** | **Auditable — attribution fields are bound to the checkout and conversion evidence** |
 
-Because AAP creates the payment object through Hyperswitch, the AAP Code is set at creation time. The merchant's PSP stores it as immutable payment metadata. Neither the agent nor the merchant can modify it after creation.
+For orchestrated payment flows, AAP can set the metadata when creating the payment object through Hyperswitch. For merchant-controlled flows, the certified integration must preserve the same fields on a durable order/application record and return them during conversion reporting.
 
 ### Verification on Webhook
 
@@ -81,8 +84,8 @@ When AAP receives a payment webhook, it:
 1. Extracts `metadata.aap_code` from the payment event.
 2. Verifies the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
 3. Decodes the payload and confirms the offer, merchant, and price match.
-4. Checks the payment amount matches the AAP Code price (within tolerance).
-5. Records the conversion as **verified** if all checks pass.
+4. Checks the transaction value matches the expected offer or merchant-defined conversion value within tolerance.
+5. Records the conversion with the appropriate verification level if all checks pass.
 
 ## Signing
 

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -4,9 +4,9 @@
 
 ## What It Is
 
-An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes everything needed for attribution in a single, tamper-proof string.
+An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes the offer, merchant, price, currency, commission terms, and expiry in a signed string.
 
-An agent cannot fake one. A merchant cannot self-issue one. A competitor cannot generate one that Rako will honour.
+An agent cannot fake a valid Rako-issued code. A merchant cannot self-issue one. A competitor cannot generate one that Rako will honour.
 
 ## Format
 
@@ -42,12 +42,12 @@ aap://rako.sh/v1/eyJ2IjoiMSIsImlzcyI6InJha28uc2giLCJvZmYiOiIwMUpRWEsxMDAxU01BUlR
 
 ## Payment Metadata Embedding
 
-When a purchase is initiated through AAP, the AAP Code is embedded in payment metadata by the AAP platform via Hyperswitch. Agents do **not** manually embed AAP Codes in order notes or descriptions.
+When a purchase is initiated through AAP, the AAP Code is embedded in payment metadata by the AAP platform through the payment orchestration layer. Agents do **not** manually embed AAP Codes in order notes or descriptions.
 
 ### How It Works
 
 1. Agent calls `POST /v1/purchase` with a `recommendationId`.
-2. AAP creates a payment link/intent on the merchant's PSP via Hyperswitch.
+2. AAP creates a payment link/intent on the merchant's PSP through the payment orchestration layer.
 3. AAP sets the following metadata on the payment object:
 
 ```json
@@ -62,7 +62,7 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 
 4. The merchant's PSP stores this metadata alongside the payment record.
 5. On payment completion, the PSP webhook delivers the metadata back to AAP.
-6. AAP verifies the `aap_code` signature and matches it to the recommendation.
+6. AAP must verify the payment event source, the `aap_code` signature, and the match between the payment metadata and the recorded recommendation before treating the conversion as verified.
 
 ### Why Platform-Side Embedding
 
@@ -70,19 +70,23 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 |----------|----------|
 | Agent embeds AAP Code in order notes | Agent can forge or omit codes |
 | Merchant embeds AAP Code at checkout | Merchant can strip codes to avoid commission |
-| **AAP embeds via Hyperswitch** | **Tamper-proof — neither agent nor merchant controls metadata** |
+| **AAP embeds through payment orchestration** | **Stronger attribution path — the agent does not control payment metadata** |
 
-Because AAP creates the payment object through Hyperswitch, the AAP Code is set at creation time. The merchant's PSP stores it as immutable payment metadata. Neither the agent nor the merchant can modify it after creation.
+Because AAP creates the payment object through the payment orchestration layer, the AAP Code is set at creation time. The protocol relies on the PSP returning that metadata in an authenticated payment event and on AAP verifying the event, signature, payload, amount, and status before recording a verified conversion.
 
 ### Verification on Webhook
 
-When AAP receives a payment webhook, it:
+For a payment event to close the verification loop, AAP must:
 
-1. Extracts `metadata.aap_code` from the payment event.
-2. Verifies the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
-3. Decodes the payload and confirms the offer, merchant, and price match.
-4. Checks the payment amount matches the AAP Code price (within tolerance).
-5. Records the conversion as **verified** if all checks pass.
+1. Authenticate the webhook as coming from the configured payment event source.
+2. Extract `metadata.aap_code` from the payment event.
+3. Verify the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
+4. Decode the payload and confirm the offer, merchant, recommendation, and price match.
+5. Check the payment amount matches the AAP Code price (within tolerance).
+6. Confirm the payment status is a successful payable state.
+7. Record the conversion as **verified** only if all checks pass.
+
+Implementation status should be stated separately from this protocol requirement. A hosted implementation that signs AAP Codes but does not yet verify those codes on the payment webhook path has not closed the verified-payment loop.
 
 ## Signing
 

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -198,7 +198,7 @@ When a valid AAP Code is present:
 4. **The commission terms are signed.** They were included in the signed payload and cannot be changed without invalidating the code.
 5. **The code is authentic.** Only Rako's private key could have produced the signature.
 
-## What the AAP Code Does NOT Guarantee
+## What the AAP Code Does NOT Prove
 
 1. **Real-time availability.** The offer may have sold out or expired since issuance. Check the `exp` field.
 2. **Price accuracy at checkout.** For live-pricing verticals (flights, hotels), the price may change. The AAP Code captures the price at discovery, not at checkout.

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -47,7 +47,7 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 ### How It Works
 
 1. Agent calls `POST /v1/purchase` with a `recommendationId`.
-2. AAP creates a payment link/intent on the merchant's PSP through the payment orchestration layer.
+2. AAP creates a payment link/intent on the merchant's payment processor through the payment orchestration layer.
 3. AAP sets the following metadata on the payment object:
 
 ```json
@@ -60,8 +60,8 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 }
 ```
 
-4. The merchant's PSP stores this metadata alongside the payment record.
-5. On payment completion, the PSP webhook delivers the metadata back to AAP.
+4. The merchant's payment processor stores this metadata alongside the payment record.
+5. On payment completion, the payment webhook delivers the metadata back to AAP.
 6. AAP must verify the payment event source, the `aap_code` signature, and the match between the payment metadata and the recorded recommendation before treating the conversion as verified.
 
 ### Why Platform-Side Embedding
@@ -72,7 +72,7 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 | Merchant embeds AAP Code at checkout | Merchant can strip codes to avoid commission |
 | **AAP embeds through payment orchestration** | **Stronger attribution path — the agent does not control payment metadata** |
 
-Because AAP creates the payment object through the payment orchestration layer, the AAP Code is set at creation time. The protocol relies on the PSP returning that metadata in an authenticated payment event and on AAP verifying the event, signature, payload, amount, and status before recording a verified conversion.
+Because AAP creates the payment object through the payment orchestration layer, the AAP Code is set at creation time. The protocol relies on the payment processor returning that metadata in an authenticated payment event and on AAP verifying the event, signature, payload, amount, and status before recording a verified conversion.
 
 ### Verification on Webhook
 
@@ -185,14 +185,14 @@ Response (invalid):
 }
 ```
 
-## What the AAP Code Guarantees
+## What the AAP Code Proves
 
 When a valid AAP Code is present:
 
-1. **The offer is real.** It was published by a verified merchant on the AAP registry.
-2. **The price is current.** It was accurate at the time of issuance.
-3. **The merchant is vetted.** They passed Rako's merchant verification.
-4. **The commission terms are immutable.** They were locked at issuance and cannot be altered retroactively.
+1. **The offer was issued by Rako.** It was published in the AAP registry when the code was created.
+2. **The price is a signed issuance snapshot.** It was accurate according to Rako's registry at the time of issuance.
+3. **The merchant identifier was recorded by Rako.** The code identifies the merchant account associated with the offer at issuance time.
+4. **The commission terms are signed.** They were included in the signed payload and cannot be changed without invalidating the code.
 5. **The code is authentic.** Only Rako's private key could have produced the signature.
 
 ## What the AAP Code Does NOT Guarantee

--- a/spec/v1/api.md
+++ b/spec/v1/api.md
@@ -147,10 +147,20 @@ Initiate checkout for a recommended offer.
 {
   "transactionId": "01KN6KWQEENKX01N1TZE3R1TPX",
   "status": "initiated",
-  "checkoutUrl": "https://merchant.com/checkout?aap_ref=...",
+  "checkoutUrl": "https://checkout.rako.sh/c/01KN6KWQEENKX01N1TZE3R1TPX",
+  "attributionMetadata": {
+    "aap_code": "aap://rako.sh/v1/...",
+    "aap_recommendation_id": "01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
+    "aap_session_id": "01KN6KV0TWMH8VS6TDS3S7V2EJ",
+    "aap_offer_id": "01JQXK1001SMARTY1GB000001",
+    "aap_merchant_id": "01JQXK0001SMARTY000000001",
+    "aap_checkout_id": "01KN6KWQEENKX01N1TZE3R1TPX"
+  },
   "session": { "id": "...", "status": "checkout" }
 }
 ```
+
+The `attributionMetadata` object is shown for protocol clarity. In hosted or payment-orchestrated checkout flows, Rako or the certified merchant integration stores these fields on the underlying checkout, payment, order, or application record. See [conversion-ledger.md](./conversion-ledger.md).
 
 ---
 
@@ -182,15 +192,30 @@ Get session details including recommendations and conversions.
 
 #### `POST /v1/conversions`
 
-Report a completed sale. Called by merchants when a transaction completes.
+Report a completed sale or merchant-defined conversion outcome. Called by merchants, certified integrations, or payment evidence sources when a transaction completes.
 
 **Request Body:**
 
 ```json
 {
   "sessionId": "01KN6KV0TWMH8VS6TDS3S7V2EJ",
+  "recommendationId": "01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
   "orderReference": "ORD-123456",
-  "transactionValue": 6.00
+  "transactionValue": 6.00,
+  "currency": "GBP",
+  "convertedAt": "2026-04-02T08:14:00.000Z",
+  "attributionMetadata": {
+    "aap_code": "aap://rako.sh/v1/...",
+    "aap_recommendation_id": "01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
+    "aap_session_id": "01KN6KV0TWMH8VS6TDS3S7V2EJ",
+    "aap_offer_id": "01JQXK1001SMARTY1GB000001",
+    "aap_merchant_id": "01JQXK0001SMARTY000000001",
+    "aap_checkout_id": "01KN6KWQEENKX01N1TZE3R1TPX"
+  },
+  "evidence": {
+    "source": "merchant_api",
+    "reference": "evt_merchant_123456"
+  }
 }
 ```
 
@@ -199,17 +224,24 @@ Report a completed sale. Called by merchants when a transaction completes.
 ```json
 {
   "conversionId": "01KN6KWQEP989CQWK1FPR94FE1",
-  "sessionId": "...",
+  "sessionId": "01KN6KV0TWMH8VS6TDS3S7V2EJ",
+  "recommendationId": "01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
   "orderReference": "ORD-123456",
   "transactionValue": 6.00,
+  "currency": "GBP",
+  "attributionPath": "aap_flow",
+  "verificationLevel": "merchant_reported",
   "commission": {
-    "amount": 8.00,
+    "commissionId": "01KN6KWQF5J2Q8V1MDZC4FXP7Z",
+    "grossCommission": 8.00,
     "networkFee": 1.60,
     "builderPayout": 6.40,
-    "type": "cpa"
+    "type": "cpa",
+    "settlementStatus": "pending"
   },
-  "status": "pending",
-  "validationPeriodDays": 30
+  "status": "pending_validation",
+  "validationPeriodDays": 30,
+  "validationEndsAt": "2026-05-02T08:14:00.000Z"
 }
 ```
 

--- a/spec/v1/attribution.md
+++ b/spec/v1/attribution.md
@@ -81,6 +81,8 @@ When `recommend()` is called, the following attribution event is created:
 | Timestamp | When the recommendation was made |
 | Fallback URL | The drop-off recovery URL |
 
+Checkout and conversion records carry additional required metadata so the recommendation can be reconciled across merchant APIs, payment orchestration, and fallback paths. See [conversion-ledger.md](./conversion-ledger.md).
+
 ## Disputes
 
 ### When Disputes Happen

--- a/spec/v1/commission.md
+++ b/spec/v1/commission.md
@@ -99,6 +99,8 @@ Builders can challenge clawbacks through the dispute process with evidence from 
 
 ## Settlement
 
+Settlement is recorded as ledger fields linked to a validated conversion. The protocol fields are defined in [conversion-ledger.md](./conversion-ledger.md); implementations may invoice merchants, batch payouts, or use external payout rails without changing the attribution record.
+
 ### Schedule
 Commission is settled monthly, after validation periods close for the relevant transactions.
 

--- a/spec/v1/commission.md
+++ b/spec/v1/commission.md
@@ -103,10 +103,10 @@ Builders can challenge clawbacks through the dispute process with evidence from 
 Commission is settled monthly, after validation periods close for the relevant transactions.
 
 ### Payment Rails
-Settlement uses standard payment infrastructure:
-- Bank transfer (UK Faster Payments / SEPA)
-- Stripe Connect (for builders with Stripe accounts)
-- Agent-to-agent payment rails (Payman, Orthogonal) as they mature
+Settlement uses standard payout infrastructure:
+- Bank transfer where supported
+- Processor-managed payout accounts where supported
+- Future agent-native payout rails as they mature
 
 ### Minimum Payout
 £25 minimum per settlement. Below threshold, balance carries forward to next period.

--- a/spec/v1/conversion-ledger.md
+++ b/spec/v1/conversion-ledger.md
@@ -1,0 +1,130 @@
+# Conversion Ledger
+
+> Required attribution metadata, conversion lifecycle, and settlement fields.
+
+The conversion ledger is the protocol record that connects a recommendation to a purchase outcome and, eventually, a settlement outcome. It is implementation-neutral: a conversion may be reported by a merchant API, verified by a payment-orchestration webhook, or reconciled from another approved payment source.
+
+## Checkout Attribution Metadata
+
+When checkout is initiated from a recommendation, the checkout record **must** carry enough metadata for Rako to match the resulting transaction back to the signed attribution event.
+
+### Required Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `aap_code` | Yes | The signed AAP Code for the recommended offer. |
+| `aap_recommendation_id` | Yes | Recommendation ID returned by `POST /v1/recommend`. |
+| `aap_session_id` | Yes | Session ID that owns the recommendation. |
+| `aap_offer_id` | Yes | Offer ID encoded in the AAP Code and recommendation. |
+| `aap_merchant_id` | Yes | Merchant ID encoded in the AAP Code and recommendation. |
+| `aap_checkout_id` | Yes | Rako checkout/transaction identifier for this checkout attempt. |
+
+### Recommended Fields
+
+| Field | Description |
+|-------|-------------|
+| `aap_protocol_version` | Protocol version, e.g. `v1`. |
+| `aap_attribution_path` | `aap_flow`, `tracked_link`, `extension`, or `influence`. |
+| `aap_created_at` | ISO-8601 timestamp when checkout was initiated. |
+| `merchant_order_reference` | Merchant order/application reference when known at checkout time. |
+| `payment_reference` | Processor, payment-orchestration, or payment-intent reference when available. |
+
+The metadata may be stored on a payment object, checkout session, order record, application record, or another durable merchant-side transaction object. It does not require a specific processor field name, but integrations **must** preserve these values until conversion reconciliation is complete.
+
+## Matching Rules
+
+A conversion is matched to a recommendation when Rako can establish all of the following:
+
+1. The `aap_code` signature is valid and unexpired at recommendation or checkout time.
+2. The `aap_recommendation_id` belongs to the `aap_session_id` and was created by the authenticated agent.
+3. The offer and merchant in the AAP Code match the checkout or conversion record.
+4. The conversion occurred within the attribution window for its path.
+5. The merchant order reference or payment reference has not already been attributed.
+
+If multiple attribution paths could match one conversion, the priority order in [attribution.md](./attribution.md) applies. One conversion can produce at most one commission record.
+
+## Conversion Ledger Record
+
+Each conversion ledger entry records the commercial outcome and the evidence used to support attribution.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `conversion_id` | Yes | Unique Rako conversion ID. |
+| `status` | Yes | Current conversion lifecycle status. |
+| `attribution_path` | Yes | `aap_flow`, `tracked_link`, `extension`, or `influence`. |
+| `verification_level` | Yes | `orchestrated`, `merchant_reported`, `payment_observed`, or `reconciled`. |
+| `session_id` | Yes | Matched AAP session ID. |
+| `recommendation_id` | Yes | Matched recommendation ID. |
+| `agent_id` | Yes | Agent that made the recommendation. |
+| `builder_id` | Yes | Builder that owns the agent. |
+| `merchant_id` | Yes | Merchant responsible for commission. |
+| `offer_id` | Yes | Offer that was recommended. |
+| `aap_code_hash` | Yes | Hash of the AAP Code used for matching; raw code storage is optional. |
+| `merchant_order_reference` | Yes | Merchant's durable order/application reference. |
+| `transaction_value` | Yes | Gross transaction value used for commission calculation. |
+| `currency` | Yes | ISO-4217 currency code. |
+| `converted_at` | Yes | When the merchant/payment source says conversion occurred. |
+| `recorded_at` | Yes | When Rako recorded the ledger entry. |
+| `validation_ends_at` | Yes | Earliest time the conversion can become commission-confirmed. |
+
+### Evidence Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `evidence_source` | Yes | Source of conversion evidence: merchant API, webhook, payment orchestrator, extension, or reconciliation import. |
+| `evidence_reference` | Yes | Source-system event, webhook, payment, order, or file reference. |
+| `evidence_received_at` | Yes | When Rako received the evidence. |
+| `evidence_hash` | Recommended | Hash of normalized evidence payload for audit and dispute handling. |
+
+## Lifecycle
+
+```
+CHECKOUT_INITIATED → CONVERSION_REPORTED → MATCHED → PENDING_VALIDATION → VALIDATED → SETTLEMENT_PENDING → SETTLED
+                                      ↓              ↓                ↓
+                                  UNMATCHED       REJECTED        DISPUTED → RESOLVED
+                                                     ↓                ↓
+                                                  CLAWED_BACK      CLAWED_BACK
+```
+
+| Status | Meaning |
+|--------|---------|
+| `checkout_initiated` | AAP created or recorded a checkout attempt with attribution metadata. |
+| `conversion_reported` | A merchant, payment source, or reconciliation process reported a conversion candidate. |
+| `matched` | Rako matched the candidate to one recommendation. |
+| `unmatched` | The candidate could not be matched; it may be retried or manually reviewed. |
+| `pending_validation` | Attribution is accepted but cancellation/chargeback/fraud windows remain open. |
+| `validated` | Validation period passed and commission can be settled. |
+| `rejected` | Conversion is invalid, cancelled before validation, fraudulent, or outside protocol rules. |
+| `settlement_pending` | Commission is confirmed and included in the next settlement run. |
+| `settled` | Builder payout and Rako network fee have been settled or booked as settled. |
+| `disputed` | Merchant or builder has challenged attribution, validation, or clawback. |
+| `resolved` | Dispute has been resolved with an audit decision. |
+| `clawed_back` | Previously pending or settled commission was reversed under the clawback rules. |
+
+## Settlement Fields
+
+A validated conversion creates or updates a commission settlement record with the following fields.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `commission_id` | Yes | Unique commission/settlement line ID. |
+| `conversion_id` | Yes | Linked conversion ledger entry. |
+| `commission_type` | Yes | `cpa`, `percentage`, or `hybrid`. |
+| `merchant_rate` | Yes | Merchant-defined commission before attribution-path adjustment. |
+| `path_multiplier` | Yes | Multiplier from the conversion path, e.g. `1.00`, `0.75`, or `0.50`. |
+| `gross_commission` | Yes | Commission owed by merchant before network fee. |
+| `network_fee_rate` | Yes | Rako network fee rate. Standard v1 rate is `0.20`. |
+| `network_fee_amount` | Yes | Amount retained by Rako. |
+| `builder_payout_amount` | Yes | Amount payable to the builder. |
+| `currency` | Yes | Settlement currency. |
+| `validation_period_days` | Yes | Validation period applied to this conversion. |
+| `settlement_status` | Yes | `pending`, `confirmed`, `invoiced`, `paid`, `reversed`, or `disputed`. |
+| `settlement_batch_id` | No | Monthly or ad hoc settlement batch identifier. |
+| `invoice_reference` | No | Merchant invoice reference, if commission is invoiced. |
+| `paid_at` | No | When builder payout was completed. |
+
+Settlement fields describe accounting outcomes only. They do not require AAP to process the customer payment or hold merchant funds.
+
+---
+
+*AAP Specification v1.0.0*

--- a/spec/v1/mcp.md
+++ b/spec/v1/mcp.md
@@ -4,7 +4,9 @@
 
 ## Overview
 
-The AAP MCP server exposes three tools that allow any MCP-compatible AI agent to discover offers, make recommendations, and initiate checkout — without writing any code.
+The AAP MCP server exposes three tools that allow an MCP-compatible AI agent to discover offers, check the requirements for a selected offer, and generate a checkout link for the user.
+
+The MCP checkout tool only returns a URL. It does not process payment, charge the user, or transfer money. The user decides whether to open the link and complete checkout.
 
 ## Installation
 
@@ -42,9 +44,9 @@ Search for product offers available through AAP.
 **Output:**
 
 Returns formatted text with:
-- Session ID (needed for recommend and checkout)
+- Session ID, used when generating a checkout link
 - Number of results
-- For each offer: provider, name, price, data, contract, network, 5G, credit check, EU roaming, offer ID
+- For each offer: provider, name, price, data, contract, network, 5G, credit check, EU roaming, and offer ID
 
 **Example interaction:**
 
@@ -52,84 +54,89 @@ Returns formatted text with:
 >
 > **Agent calls** `search_offers({ vertical: "sim", min_data_gb: 10, contract_months: 0 })`
 >
-> **Returns:** 4 offers from SMARTY, giffgaff, VOXI, Lebara with session ID
+> **Returns:** 4 offers from SMARTY, giffgaff, VOXI, Lebara with a session ID
 
-### `recommend`
+### `get_checkout_requirements`
 
-Record a product recommendation and log the attribution event.
+Return the information, confirmations, eligibility checks, and constraints needed before generating checkout for a specific offer.
 
 **Input:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID from search_offers |
-| `offer_id` | string | Yes | ID of the offer to recommend |
-| `context` | string | No | Why this offer was recommended |
+| `offer_id` | string | Yes | Offer ID from `search_offers` |
 
 **Output:**
 
 Returns:
-- Recommendation ID
-- Offer summary (provider, name, price)
-- Fallback URL for drop-off recovery
-- Confirmation that attribution was recorded
+- Required fields or confirmations
+- Eligibility criteria to check with the user
+- Offer-specific constraints
+- Suggested next step before calling `get_checkout_link`
 
 **Example interaction:**
 
-> **Agent:** Based on your needs, I recommend the SMARTY 30GB Rolling Monthly at £10/month. No contract, no credit check, unlimited calls and texts.
+> **Agent:** SMARTY 30GB looks like the best match because it gives you more data at the same price and keeps the rolling monthly terms you asked for.
 >
-> **Agent calls** `recommend({ session_id: "...", offer_id: "...", context: "User wanted cheap SIM, 10GB+, no contract" })`
+> **Agent calls** `get_checkout_requirements({ offer_id: "..." })`
+>
+> **Returns:** any required confirmations and checkout constraints for that offer
 
-### `checkout`
+### `get_checkout_link`
 
-Initiate checkout for a recommended offer.
+Generate a hosted checkout link for the selected offer. This records the attribution context internally and returns a URL the user can open to complete checkout.
+
+This tool does **not** process payment, charge the user, or transfer money. It only generates the checkout link.
 
 **Input:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID from search_offers |
-| `recommendation_id` | string | Yes | Recommendation ID from recommend |
+| `session_id` | string | Yes | Session ID from `search_offers` |
+| `offer_id` | string | Yes | Offer ID the user selected |
+| `context` | string | No | Why this offer was chosen |
 
 **Output:**
 
 Returns:
-- Transaction ID
+- Checkout URL, if generated
 - Status
-- Checkout URL (if applicable)
+- Attribution reference details, when available
 
 **Example interaction:**
 
 > **User:** Yes, I'd like to go with that SMARTY deal.
 >
-> **Agent calls** `checkout({ session_id: "...", recommendation_id: "..." })`
+> **Agent calls** `get_checkout_link({ session_id: "...", offer_id: "...", context: "Best match: 30GB for £10 rolling monthly" })`
 
 ## Full Conversation Flow
 
-```
+```text
 User: I need a new SIM deal. Something cheap, at least 10GB, no contract.
 
 Agent: [calls search_offers(vertical="sim", min_data_gb=10, contract_months=0)]
        I found 4 options for you:
 
        1. SMARTY 30GB — £10/month (Three network, no credit check)
-       2. giffgaff 10GB — £10/month (O2 network, 5G included)  
+       2. giffgaff 10GB — £10/month (O2 network, 5G included)
        3. giffgaff 25GB — £12/month (O2 network, 5G included)
        4. Lebara 5GB — £5/month (Vodafone network)
 
-       I'd recommend the SMARTY 30GB at £10/month — you get 3x the data
-       of the giffgaff 10GB plan at the same price, and no credit check.
-
-       [calls recommend(session_id, offer_id, context="Best value: 30GB for £10")]
+       SMARTY 30GB looks like the best match because it gives you more data
+       at the same price and keeps the rolling monthly terms you asked for.
 
 User: Sounds good, let's go with SMARTY.
 
-Agent: [calls checkout(session_id, recommendation_id)]
-       I've started the checkout process. Here's a link if you'd like to 
-       complete the purchase: https://aap.link/r/...
+Agent: [calls get_checkout_requirements(offer_id)]
+       Before I generate the checkout link, please confirm you're happy with
+       the rolling monthly SIM terms and that you'll complete checkout yourself.
 
-       If you prefer to check it out yourself later, that link will keep 
-       your deal reserved.
+User: Yes, that's fine.
+
+Agent: [calls get_checkout_link(session_id, offer_id, context="Best match: 30GB for £10 rolling monthly")]
+       Here's your checkout link: https://aap.link/r/...
+
+       You can open the link to review the merchant checkout and complete the purchase.
 ```
 
 ## Environment Variables

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -4,7 +4,7 @@
 
 ## Core Principle
 
-AAP does not process payments. AAP orchestrates payments on the merchant's own payment processor via Hyperswitch. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
+AAP does not need to process customer funds to attribute a conversion. In the default AAP flow, AAP can orchestrate checkout on the merchant's own payment processor via Hyperswitch or another approved payment-orchestration path. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
 
 ---
 
@@ -15,8 +15,8 @@ AAP does not process payments. AAP orchestrates payments on the merchant's own p
 The agent recommends. The user completes checkout.
 
 ```
-Agent → POST /v1/purchase { recommendationId }
-  ← { checkoutUrl, paymentId }
+Agent → POST /v1/checkout { recommendationId }
+  ← { checkoutUrl, transactionId }
 
 User → opens checkoutUrl (Hyperswitch payment link)
   → enters card on merchant's PSP-hosted checkout
@@ -27,7 +27,7 @@ Hyperswitch → webhook to AAP
 ```
 
 **Flow:**
-1. Agent calls `POST /v1/purchase` with the `recommendationId` from a prior recommendation.
+1. Agent calls `POST /v1/checkout` with the `recommendationId` from a prior recommendation.
 2. AAP creates a Hyperswitch payment link on the merchant's connected processor.
 3. AAP embeds the AAP Code in the payment's `metadata.aap_code` field.
 4. The checkout URL is returned to the agent, which presents it to the user.
@@ -41,8 +41,8 @@ Hyperswitch → webhook to AAP
 The agent has stored payment credentials and completes the purchase without user interaction.
 
 ```
-Agent → POST /v1/purchase { recommendationId, paymentMethod }
-  ← { confirmation, paymentId, status }
+Agent → POST /v1/checkout { recommendationId, paymentMethod }
+  ← { confirmation, transactionId, status }
 
 Hyperswitch → processes via merchant's PSP
   → webhook to AAP
@@ -50,7 +50,7 @@ Hyperswitch → processes via merchant's PSP
 ```
 
 **Flow:**
-1. Agent calls `POST /v1/purchase` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
+1. Agent calls `POST /v1/checkout` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
 2. AAP creates a Hyperswitch payment intent and processes it directly.
 3. AAP Code is embedded in payment metadata.
 4. Payment settles to merchant via merchant's PSP. AAP never touches funds.
@@ -78,12 +78,18 @@ AAP trusts the PSP. The PSP reports what happened: payment created, succeeded or
 
 | Level | Source | Trust | Commission Rate | Settlement Speed |
 |-------|--------|-------|-----------------|------------------|
-| **Verified** | Hyperswitch PSP webhook | Trustless — neutral third party confirms payment | Full commission | Standard (after validation period) |
-| **Unverified** | Agent callback or merchant self-report | Trust-dependent — requires validation period | Reduced commission (75%) | Delayed (extended validation period) |
+| **Orchestrated** | Payment-orchestration webhook with AAP metadata | Strong — neutral payment source confirms payment | Full commission | Standard (after validation period) |
+| **Merchant-reported** | Merchant conversion API or webhook | Merchant attestation plus audit rights | Path-dependent | Standard or extended validation period |
+| **Payment-observed** | Payment processor, open banking, or reconciliation feed | Strong where source is independent | Path-dependent | Standard (after validation period) |
+| **Reconciled** | Batch import or manual reconciliation | Evidence-dependent | Path-dependent | Delayed or manual review |
 
-**Verified conversions** are confirmed by the merchant's payment processor via Hyperswitch webhook. The processor has no relationship with AAP and no reason to fabricate or hide transactions.
+**Orchestrated conversions** are confirmed by a payment source such as a Hyperswitch-normalized PSP webhook that carries AAP metadata.
 
-**Unverified conversions** occur when the purchase happens outside AAP's orchestration (e.g., tracked link fallback). These rely on agent callbacks or merchant reporting and carry a longer validation period and reduced commission.
+**Merchant-reported conversions** occur when the purchase happens in a merchant-controlled flow or non-payment conversion event. These rely on merchant attestation, audit logs, and validation periods.
+
+**Payment-observed conversions** are confirmed by payment data even if AAP did not create the checkout object.
+
+**Reconciled conversions** are matched from later data sources and may require manual review before settlement.
 
 ---
 
@@ -119,21 +125,24 @@ Merchants connect their existing PSP account to AAP via OAuth:
 
 ---
 
-## AAP Code in Payment Metadata
+## Checkout Attribution Metadata
 
-Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
+Every AAP-orchestrated checkout carries AAP attribution metadata on the durable checkout, payment, order, application, or equivalent transaction object. For payment-orchestrated flows, this is usually payment metadata:
 
 ```json
 {
   "metadata": {
     "aap_code": "aap://rako.sh/v1/{base64url_payload}.{base64url_signature}",
-    "aap_recommendation_id": "01JQXK1001SMARTY1GB000001",
-    "aap_session_id": "sess_abc123"
+    "aap_recommendation_id": "01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
+    "aap_session_id": "sess_abc123",
+    "aap_offer_id": "01JQXK1001SMARTY1GB000001",
+    "aap_merchant_id": "01JQXK0001SMARTY000000001",
+    "aap_checkout_id": "01KN6KWQEENKX01N1TZE3R1TPX"
   }
 }
 ```
 
-This is set by AAP when creating the payment via Hyperswitch — not by the agent. The agent cannot modify or forge payment metadata. The PSP stores it alongside the payment record, creating a tamper-proof attribution link.
+This is set by AAP or by a certified merchant integration when creating the checkout record — not by the agent. The agent cannot modify or forge the metadata. The checkout system stores it alongside the transaction record, creating an auditable attribution link. Required and recommended fields are defined in [conversion-ledger.md](./conversion-ledger.md).
 
 On webhook receipt, AAP verifies:
 1. The `aap_code` signature is valid (Ed25519 verification).
@@ -141,7 +150,7 @@ On webhook receipt, AAP verifies:
 3. The payment amount matches the offer price (within tolerance).
 4. The payment status is `succeeded`.
 
-If all checks pass, the conversion is recorded as **verified**.
+If all checks pass, the conversion is recorded in the conversion ledger with the appropriate verification level.
 
 ---
 

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -23,8 +23,8 @@ Agent → POST /v1/purchase { recommendationId }
   ← { checkoutUrl, paymentId }
 
 User → opens checkoutUrl (hosted payment link)
-  → enters card on merchant's PSP-hosted checkout
-  → payment settles to merchant via merchant's PSP
+  → enters card on merchant-processor-hosted checkout
+  → payment settles to merchant via merchant's payment processor
 
 Payment webhook → AAP
   → AAP records conversion after required verification checks pass
@@ -35,8 +35,8 @@ Payment webhook → AAP
 2. AAP creates a hosted payment link on the merchant's connected processor.
 3. AAP embeds the AAP Code in the payment's `metadata.aap_code` field.
 4. The checkout URL is returned to the agent, which presents it to the user.
-5. The user enters payment credentials directly into the PSP-hosted checkout.
-6. Payment settles from buyer → merchant's PSP → merchant. AAP never touches funds.
+5. The user enters payment credentials directly into the merchant-processor-hosted checkout.
+6. In the intended merchant-processor model, payment settles from buyer → merchant's payment processor → merchant. AAP does not receive or control buyer funds.
 7. The payment orchestration layer sends a webhook to AAP with the payment outcome.
 8. AAP records the conversion as **verified** only after the webhook signature, AAP Code signature, metadata payload, amount, and payment status checks pass.
 
@@ -48,7 +48,7 @@ The agent has stored payment credentials and completes the purchase without user
 Agent → POST /v1/purchase { recommendationId, paymentMethod }
   ← { confirmation, paymentId, status }
 
-Payment orchestration layer → processes via merchant's PSP
+Payment orchestration layer → processes via merchant's payment processor
   → webhook to AAP
   → AAP records conversion after required verification checks pass
 ```
@@ -57,7 +57,7 @@ Payment orchestration layer → processes via merchant's PSP
 1. Agent calls `POST /v1/purchase` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
 2. AAP creates a payment intent on the merchant's connected processor and requests confirmation.
 3. AAP Code is embedded in payment metadata.
-4. Payment settles to merchant via merchant's PSP. AAP never touches funds.
+4. In the intended merchant-processor model, payment settles to the merchant via the merchant's payment processor. AAP does not receive or control buyer funds.
 5. Webhook confirms outcome. Conversion is recorded as verified only after the same webhook, AAP Code, payload, amount, and status checks pass.
 
 **Note:** Mode 2 requires the agent to have legitimate stored payment credentials from the user. AAP does not vault or manage user payment credentials.
@@ -74,15 +74,15 @@ Every party in the transaction has an incentive to misreport:
 |-------|-----------|
 | Agent | Wants commission — could fabricate conversions |
 | Merchant | Wants to avoid commission — could deny conversions |
-| Merchant's PSP | No stake in AAP's commission — neutral third party |
+| Merchant's payment processor | No stake in AAP's commission — independent payment evidence source |
 
-The protocol treats the merchant's PSP as the independent evidence source. A payment event is eligible to become a verified conversion only when AAP can authenticate the event source and reconcile the amount, status, recommendation, offer, and signed AAP Code.
+The protocol treats the merchant's payment processor as the independent evidence source. A payment event is eligible to become a verified conversion only when AAP can authenticate the event source and reconcile the amount, status, recommendation, offer, and signed AAP Code.
 
 ### Verification Levels
 
 | Level | Source | Trust | Commission Rate | Settlement Speed |
 |-------|--------|-------|-----------------|------------------|
-| **Verified** | Authenticated PSP payment webhook plus AAP reconciliation checks | Independent payment evidence confirms the payable outcome | Full commission | Standard (after validation period) |
+| **Verified** | Authenticated payment webhook plus AAP reconciliation checks | Independent payment evidence confirms the payable outcome | Full commission | Standard (after validation period) |
 | **Unverified** | Agent callback or merchant self-report | Trust-dependent — requires validation period | Reduced commission (75%) | Delayed (extended validation period) |
 
 **Verified conversions** require an authenticated event from the merchant's payment processor and successful reconciliation against the signed AAP Code, recommendation, offer, amount, and payment status.
@@ -97,21 +97,21 @@ AAP introduces **zero additional payment processing fees**.
 
 | Fee | Who Pays | To Whom |
 |-----|----------|---------|
-| PSP processing fee (e.g., 1.4% + 20p) | Merchant | Merchant's PSP (Stripe, Adyen, etc.) |
+| Payment processing fee (example rate set by processor) | Merchant | Merchant's payment processor |
 | AAP commission (e.g., £8 CPA) | Merchant | AAP (invoiced monthly as B2B receivable) |
 | AAP network fee (20% of commission) | Deducted from commission | AAP retains; remainder to Agent Builder |
 
-The merchant pays exactly the same PSP fees they'd pay without AAP. Commission is a separate invoice, not a deduction from payment funds.
+The merchant pays the same payment-processing fees they would pay without AAP. Commission is a separate invoice, not a deduction from payment funds.
 
 ---
 
-## Merchant Onboarding (OAuth)
+## Merchant Payment Connector Onboarding
 
-Merchants connect their existing PSP account to AAP via OAuth:
+Merchants connect their existing payment processor account to AAP through a scoped connector flow:
 
-1. Merchant clicks **"Connect your Stripe"** on the AAP dashboard.
-2. OAuth flow redirects to Stripe (or Adyen, Worldpay, etc.).
-3. Merchant authorises scoped access (minimum required permissions).
+1. Merchant clicks **"Connect payment processor"** on the AAP dashboard.
+2. The connector flow redirects to the merchant's selected processor or processor-authorisation page.
+3. Merchant authorises scoped access with the minimum required permissions.
 4. AAP stores the authorised connector configuration for the merchant account.
 5. AAP can now create payment links and receive payment events for that merchant account.
 
@@ -125,7 +125,7 @@ Merchants connect their existing PSP account to AAP via OAuth:
 
 ## AAP Code in Payment Metadata
 
-Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
+Every AAP-orchestrated payment embeds the AAP Code in the payment metadata:
 
 ```json
 {
@@ -154,17 +154,17 @@ If any check is missing or fails, the conversion must remain unverified, pending
 
 ## Payment Orchestration Role
 
-AAP uses a payment orchestration layer between AAP and the merchant's PSP. The orchestration layer is **not** itself the merchant's payment processor.
+AAP uses a payment orchestration layer between AAP and the merchant's payment processor. The orchestration layer is **not** itself the merchant's payment processor.
 
-- Does not hold money
-- Does not move money
-- Does not replace the merchant's PSP
+- Does not hold buyer funds
+- Does not become the merchant of record
+- Does not replace the merchant's payment processor
 
 The orchestration layer provides:
 - **One API** for AAP to create payments across supported processors
 - **Payment links** — hosted checkout pages
 - **Webhooks** — unified event format regardless of underlying processor
-- **Connector framework** — merchant connects their PSP once, AAP uses it for eligible transactions
+- **Connector framework** — merchant connects their payment processor once, AAP uses it for eligible transactions
 
 ---
 

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -1,10 +1,14 @@
 # Payment Architecture
 
-> How AAP verifies purchases trustlessly without processing payments.
+> Protocol design for payment-observed attribution without Rako processing customer payments.
+
+## Implementation Status
+
+This document describes the AAP v1 payment architecture and verification requirements. Rako's hosted implementation is still closing the full payment-verification loop: payment webhooks, AAP Code verification on webhook receipt, amount matching, and payload matching must all be implemented and tested before public materials should describe hosted conversions as fully verified, trustless, or tamper-proof.
 
 ## Core Principle
 
-AAP does not process payments. AAP orchestrates payments on the merchant's own payment processor via Hyperswitch. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
+AAP does not process payments. In the designed production model, AAP orchestrates payments on the merchant's own payment processor through a payment orchestration layer. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
 
 ---
 
@@ -18,23 +22,23 @@ The agent recommends. The user completes checkout.
 Agent → POST /v1/purchase { recommendationId }
   ← { checkoutUrl, paymentId }
 
-User → opens checkoutUrl (Hyperswitch payment link)
+User → opens checkoutUrl (hosted payment link)
   → enters card on merchant's PSP-hosted checkout
   → payment settles to merchant via merchant's PSP
 
-Hyperswitch → webhook to AAP
-  → AAP records verified conversion
+Payment webhook → AAP
+  → AAP records conversion after required verification checks pass
 ```
 
 **Flow:**
 1. Agent calls `POST /v1/purchase` with the `recommendationId` from a prior recommendation.
-2. AAP creates a Hyperswitch payment link on the merchant's connected processor.
+2. AAP creates a hosted payment link on the merchant's connected processor.
 3. AAP embeds the AAP Code in the payment's `metadata.aap_code` field.
 4. The checkout URL is returned to the agent, which presents it to the user.
 5. The user enters payment credentials directly into the PSP-hosted checkout.
 6. Payment settles from buyer → merchant's PSP → merchant. AAP never touches funds.
-7. Hyperswitch fires a webhook to AAP confirming the payment outcome.
-8. AAP records the conversion as **verified** (trustless — confirmed by neutral PSP).
+7. The payment orchestration layer sends a webhook to AAP with the payment outcome.
+8. AAP records the conversion as **verified** only after the webhook signature, AAP Code signature, metadata payload, amount, and payment status checks pass.
 
 ### Mode 2 — Agent Autonomous
 
@@ -44,17 +48,17 @@ The agent has stored payment credentials and completes the purchase without user
 Agent → POST /v1/purchase { recommendationId, paymentMethod }
   ← { confirmation, paymentId, status }
 
-Hyperswitch → processes via merchant's PSP
+Payment orchestration layer → processes via merchant's PSP
   → webhook to AAP
-  → AAP records verified conversion
+  → AAP records conversion after required verification checks pass
 ```
 
 **Flow:**
 1. Agent calls `POST /v1/purchase` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
-2. AAP creates a Hyperswitch payment intent and processes it directly.
+2. AAP creates a payment intent on the merchant's connected processor and requests confirmation.
 3. AAP Code is embedded in payment metadata.
 4. Payment settles to merchant via merchant's PSP. AAP never touches funds.
-5. Webhook confirms outcome. Conversion recorded as verified.
+5. Webhook confirms outcome. Conversion is recorded as verified only after the same webhook, AAP Code, payload, amount, and status checks pass.
 
 **Note:** Mode 2 requires the agent to have legitimate stored payment credentials from the user. AAP does not vault or manage user payment credentials.
 
@@ -62,7 +66,7 @@ Hyperswitch → processes via merchant's PSP
 
 ## Verification Model
 
-### Why Trustless Verification Matters
+### Why Independent Payment Verification Matters
 
 Every party in the transaction has an incentive to misreport:
 
@@ -72,16 +76,16 @@ Every party in the transaction has an incentive to misreport:
 | Merchant | Wants to avoid commission — could deny conversions |
 | Merchant's PSP | No stake in AAP's commission — neutral third party |
 
-AAP trusts the PSP. The PSP reports what happened: payment created, succeeded or failed, amount and metadata. This is the same trust model as a bank statement.
+The protocol treats the merchant's PSP as the independent evidence source. A payment event is eligible to become a verified conversion only when AAP can authenticate the event source and reconcile the amount, status, recommendation, offer, and signed AAP Code.
 
 ### Verification Levels
 
 | Level | Source | Trust | Commission Rate | Settlement Speed |
 |-------|--------|-------|-----------------|------------------|
-| **Verified** | Hyperswitch PSP webhook | Trustless — neutral third party confirms payment | Full commission | Standard (after validation period) |
+| **Verified** | Authenticated PSP payment webhook plus AAP reconciliation checks | Independent payment evidence confirms the payable outcome | Full commission | Standard (after validation period) |
 | **Unverified** | Agent callback or merchant self-report | Trust-dependent — requires validation period | Reduced commission (75%) | Delayed (extended validation period) |
 
-**Verified conversions** are confirmed by the merchant's payment processor via Hyperswitch webhook. The processor has no relationship with AAP and no reason to fabricate or hide transactions.
+**Verified conversions** require an authenticated event from the merchant's payment processor and successful reconciliation against the signed AAP Code, recommendation, offer, amount, and payment status.
 
 **Unverified conversions** occur when the purchase happens outside AAP's orchestration (e.g., tracked link fallback). These rely on agent callbacks or merchant reporting and carry a longer validation period and reduced commission.
 
@@ -108,8 +112,8 @@ Merchants connect their existing PSP account to AAP via OAuth:
 1. Merchant clicks **"Connect your Stripe"** on the AAP dashboard.
 2. OAuth flow redirects to Stripe (or Adyen, Worldpay, etc.).
 3. Merchant authorises scoped access (minimum required permissions).
-4. AAP stores the access token as a Hyperswitch connector.
-5. AAP can now create payment links and receive webhooks on the merchant's account.
+4. AAP stores the authorised connector configuration for the merchant account.
+5. AAP can now create payment links and receive payment events for that merchant account.
 
 **Scope restrictions (ENG-08):**
 - Read payment intents and payment methods
@@ -133,31 +137,34 @@ Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
 }
 ```
 
-This is set by AAP when creating the payment via Hyperswitch — not by the agent. The agent cannot modify or forge payment metadata. The PSP stores it alongside the payment record, creating a tamper-proof attribution link.
+This is set by AAP when creating the payment through the payment orchestration layer — not by the agent. The agent cannot modify the metadata AAP sets on that payment object.
 
-On webhook receipt, AAP verifies:
-1. The `aap_code` signature is valid (Ed25519 verification).
-2. The `aap_code` payload matches the recommendation and offer.
-3. The payment amount matches the offer price (within tolerance).
-4. The payment status is `succeeded`.
+For a conversion to be recorded as **verified**, AAP must verify all of the following on webhook receipt:
+1. The payment webhook is authenticated as coming from the configured payment event source.
+2. The `aap_code` signature is valid (Ed25519 verification).
+3. The `aap_code` payload matches the recommendation and offer.
+4. The payment amount matches the offer price (within tolerance).
+5. The payment status is `succeeded`.
 
-If all checks pass, the conversion is recorded as **verified**.
+If any check is missing or fails, the conversion must remain unverified, pending, or rejected according to the implementation's risk policy.
+
+**Hosted implementation note:** these checks are protocol requirements. Public hosted-Rako claims should not describe a payment conversion as fully verified, trustless, or tamper-proof unless the deployed webhook handler implements and tests every check above.
 
 ---
 
-## Hyperswitch's Role
+## Payment Orchestration Role
 
-Hyperswitch is an open-source payment switch. It is **not** a payment processor.
+AAP uses a payment orchestration layer between AAP and the merchant's PSP. The orchestration layer is **not** itself the merchant's payment processor.
 
 - Does not hold money
 - Does not move money
-- Does not compete with Stripe, Adyen, or Worldpay
+- Does not replace the merchant's PSP
 
-Hyperswitch provides:
-- **One API** for AAP to create payments across 275+ processors
+The orchestration layer provides:
+- **One API** for AAP to create payments across supported processors
 - **Payment links** — hosted checkout pages
 - **Webhooks** — unified event format regardless of underlying processor
-- **Connector framework** — merchant connects their PSP once, AAP uses it for all transactions
+- **Connector framework** — merchant connects their PSP once, AAP uses it for eligible transactions
 
 ---
 

--- a/spec/v1/security.md
+++ b/spec/v1/security.md
@@ -65,7 +65,7 @@ This creates a tamper-evident audit trail. Modifying any event breaks the chain 
 
 ### Open Spec, Centralised Trust
 
-AAP uses the same trust model as DNS, Visa, and Stripe:
+AAP uses a familiar open-spec, centralised-operator trust model:
 
 | Layer | Open or Centralised |
 |-------|-------------------|
@@ -99,7 +99,7 @@ The same question comes up every time someone builds a trust layer. The answer f
 - **Speed:** Agent transactions happen in milliseconds. Block confirmation takes seconds to minutes.
 - **Cost:** Per-transaction on-chain fees eat into commissions.
 - **Privacy:** On-chain data is visible. Merchant and builder data must be siloed.
-- **Equivalent guarantee:** Hash-chained signed logs provide the same tamper-evidence without distributed consensus overhead.
+- **Equivalent audit property:** Hash-chained signed logs provide tamper-evidence without distributed consensus overhead.
 
 The trust comes from cryptography, not consensus. Ed25519 signatures are just as unforgeable whether they're stored in a database or on a blockchain.
 
@@ -119,7 +119,7 @@ The trust comes from cryptography, not consensus. Ed25519 signatures are just as
 ### Rate Limiting
 - Per-key rate limits prevent abuse
 - Graduated response: slow down → temporary block → review
-- DDoS protection via Cloudflare
+- Network-level DDoS protections at the edge
 
 ---
 


### PR DESCRIPTION
Closes https://github.com/rakohq/aap-spec/issues/1

## Summary
- Add `spec/v1/conversion-ledger.md` defining checkout attribution metadata, matching rules, conversion lifecycle states, evidence fields, and settlement fields.
- Update API examples for checkout and conversion reporting to include attribution metadata, verification level, lifecycle status, and settlement status.
- Rework the PR against spec PR #3 and #4 so checkout metadata, MCP checkout-link terminology, and payment-verification beta caveats are aligned.
- Resolve conflicts in `spec/v1/aap-code.md` and `spec/v1/payments.md` with public guardrails: vendor-neutral payment orchestration language and no internal vendor names or over-strong trust/guarantee wording.

## Verification
- `git diff origin/main...HEAD --check`: passed.
- Guardrail grep across repo: `rg -n -i '\b(Hyperswitch|Stripe Connect|trustless|tamper[- ]proof|earn commission|guarantee|guarantees|guaranteed)\b' .` → clean.
- Conflict marker grep: `rg -n '<<<<<<<|=======|>>>>>>>' .` → clean.
- Python relative Markdown link check across `*.md`: `Markdown relative links OK`.
- Synthetic post-PR #3/#4 merge check: merged `origin/spec-trust-claims-audit` then `origin/spec-mcp-canonical-flow` into a temp base, then merged this branch → automatic merge succeeded.
- Inspected repository for package/config-based checks; no package manifest, Makefile, or lint config is present.

## Compatibility / implementation impact
- Protocol remains backwards-aware by documenting ledger fields and metadata without requiring a specific PSP, payment orchestrator, or direct processor field.
- Backend/SDK/docs should align checkout and conversion objects with the required `aap_*` metadata fields and lifecycle/settlement terminology.
- Payment-verification language remains beta-safe: public hosted-Rako materials should not describe conversions as fully payment-verified unless webhook authentication plus AAP Code, metadata, amount, and status reconciliation are implemented and tested.

## Landing notes
- This PR has been reworked to land after PR #3 and PR #4. Until those PRs land, this PR may show their merged context in the diff.
- No external publishing, package release, production/payment changes, or sensitive claims were made.
