### PR TITLE
docs: clarify payment verification status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The open standard for AI agent affiliate attribution.
 
-AAP defines how AI agents discover offers, record recommendations, and earn commission when those recommendations lead to purchases — without cookies, tracking pixels, or browser sessions.
+AAP defines how AI agents discover offers, record recommendations, and preserve attribution when those recommendations lead to eligible conversions — without cookies, tracking pixels, or browser sessions.
 
 ## Documents
 

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -20,7 +20,7 @@ AAP is an open spec with a centralised trust model. The specification is public 
 Businesses that sell products or services. They publish offers into the AAP registry and pay commission when agent-driven recommendations lead to sales.
 
 ### Agent Builders
-Developers who build AI agents. They integrate the AAP SDK so their agents can discover offers, make recommendations, and earn commission.
+Developers who build AI agents. They integrate the AAP SDK so their agents can discover offers, make recommendations, and preserve attribution for eligible conversions.
 
 ### Agents
 AI systems (Claude, ChatGPT, custom agents) that recommend products to users on behalf of their builders.
@@ -29,7 +29,7 @@ AI systems (Claude, ChatGPT, custom agents) that recommend products to users on 
 The entity that operates the AAP infrastructure:
 - Issues and signs AAP Codes
 - Operates the offer registry
-- Verifies merchants and agents
+- Registers merchants and agents
 - Matches recommendations to conversions
 - Calculates and settles commission
 - Provides fraud detection

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -120,7 +120,7 @@ CREATED → ACTIVE → CHECKOUT → CONVERTED → VALIDATED → SETTLED
 - **[Commission Model](./commission.md)** — Types, floors, calculation, settlement
 - **[API Reference](./api.md)** — REST endpoints
 - **[MCP Integration](./mcp.md)** — MCP tool definitions
-- **[Payment Architecture](./payments.md)** — Payment modes, verification, Hyperswitch integration
+- **[Payment Architecture](./payments.md)** — Payment modes, verification requirements, and payment orchestration
 - **[Security](./security.md)** — Signing, fraud prevention, trust model
 
 ## 8. Versioning

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -4,9 +4,9 @@
 
 ## What It Is
 
-An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes everything needed for attribution in a single, tamper-proof string.
+An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes the offer, merchant, price, currency, commission terms, and expiry in a signed string.
 
-An agent cannot fake one. A merchant cannot self-issue one. A competitor cannot generate one that Rako will honour.
+An agent cannot fake a valid Rako-issued code. A merchant cannot self-issue one. A competitor cannot generate one that Rako will honour.
 
 ## Format
 
@@ -42,12 +42,12 @@ aap://rako.sh/v1/eyJ2IjoiMSIsImlzcyI6InJha28uc2giLCJvZmYiOiIwMUpRWEsxMDAxU01BUlR
 
 ## Payment Metadata Embedding
 
-When a purchase is initiated through AAP, the AAP Code is embedded in payment metadata by the AAP platform via Hyperswitch. Agents do **not** manually embed AAP Codes in order notes or descriptions.
+When a purchase is initiated through AAP, the AAP Code is embedded in payment metadata by the AAP platform through the payment orchestration layer. Agents do **not** manually embed AAP Codes in order notes or descriptions.
 
 ### How It Works
 
 1. Agent calls `POST /v1/purchase` with a `recommendationId`.
-2. AAP creates a payment link/intent on the merchant's PSP via Hyperswitch.
+2. AAP creates a payment link/intent on the merchant's PSP through the payment orchestration layer.
 3. AAP sets the following metadata on the payment object:
 
 ```json
@@ -62,7 +62,7 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 
 4. The merchant's PSP stores this metadata alongside the payment record.
 5. On payment completion, the PSP webhook delivers the metadata back to AAP.
-6. AAP verifies the `aap_code` signature and matches it to the recommendation.
+6. AAP must verify the payment event source, the `aap_code` signature, and the match between the payment metadata and the recorded recommendation before treating the conversion as verified.
 
 ### Why Platform-Side Embedding
 
@@ -70,19 +70,23 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 |----------|----------|
 | Agent embeds AAP Code in order notes | Agent can forge or omit codes |
 | Merchant embeds AAP Code at checkout | Merchant can strip codes to avoid commission |
-| **AAP embeds via Hyperswitch** | **Tamper-proof — neither agent nor merchant controls metadata** |
+| **AAP embeds through payment orchestration** | **Stronger attribution path — the agent does not control payment metadata** |
 
-Because AAP creates the payment object through Hyperswitch, the AAP Code is set at creation time. The merchant's PSP stores it as immutable payment metadata. Neither the agent nor the merchant can modify it after creation.
+Because AAP creates the payment object through the payment orchestration layer, the AAP Code is set at creation time. The protocol relies on the PSP returning that metadata in an authenticated payment event and on AAP verifying the event, signature, payload, amount, and status before recording a verified conversion.
 
 ### Verification on Webhook
 
-When AAP receives a payment webhook, it:
+For a payment event to close the verification loop, AAP must:
 
-1. Extracts `metadata.aap_code` from the payment event.
-2. Verifies the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
-3. Decodes the payload and confirms the offer, merchant, and price match.
-4. Checks the payment amount matches the AAP Code price (within tolerance).
-5. Records the conversion as **verified** if all checks pass.
+1. Authenticate the webhook as coming from the configured payment event source.
+2. Extract `metadata.aap_code` from the payment event.
+3. Verify the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
+4. Decode the payload and confirm the offer, merchant, recommendation, and price match.
+5. Check the payment amount matches the AAP Code price (within tolerance).
+6. Confirm the payment status is a successful payable state.
+7. Record the conversion as **verified** only if all checks pass.
+
+Implementation status should be stated separately from this protocol requirement. A hosted implementation that signs AAP Codes but does not yet verify those codes on the payment webhook path has not closed the verified-payment loop.
 
 ## Signing
 

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -47,7 +47,7 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 ### How It Works
 
 1. Agent calls `POST /v1/purchase` with a `recommendationId`.
-2. AAP creates a payment link/intent on the merchant's PSP through the payment orchestration layer.
+2. AAP creates a payment link/intent on the merchant's payment processor through the payment orchestration layer.
 3. AAP sets the following metadata on the payment object:
 
 ```json
@@ -60,8 +60,8 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 }
 ```
 
-4. The merchant's PSP stores this metadata alongside the payment record.
-5. On payment completion, the PSP webhook delivers the metadata back to AAP.
+4. The merchant's payment processor stores this metadata alongside the payment record.
+5. On payment completion, the payment webhook delivers the metadata back to AAP.
 6. AAP must verify the payment event source, the `aap_code` signature, and the match between the payment metadata and the recorded recommendation before treating the conversion as verified.
 
 ### Why Platform-Side Embedding
@@ -72,7 +72,7 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 | Merchant embeds AAP Code at checkout | Merchant can strip codes to avoid commission |
 | **AAP embeds through payment orchestration** | **Stronger attribution path — the agent does not control payment metadata** |
 
-Because AAP creates the payment object through the payment orchestration layer, the AAP Code is set at creation time. The protocol relies on the PSP returning that metadata in an authenticated payment event and on AAP verifying the event, signature, payload, amount, and status before recording a verified conversion.
+Because AAP creates the payment object through the payment orchestration layer, the AAP Code is set at creation time. The protocol relies on the payment processor returning that metadata in an authenticated payment event and on AAP verifying the event, signature, payload, amount, and status before recording a verified conversion.
 
 ### Verification on Webhook
 
@@ -185,14 +185,14 @@ Response (invalid):
 }
 ```
 
-## What the AAP Code Guarantees
+## What the AAP Code Proves
 
 When a valid AAP Code is present:
 
-1. **The offer is real.** It was published by a verified merchant on the AAP registry.
-2. **The price is current.** It was accurate at the time of issuance.
-3. **The merchant is vetted.** They passed Rako's merchant verification.
-4. **The commission terms are immutable.** They were locked at issuance and cannot be altered retroactively.
+1. **The offer was issued by Rako.** It was published in the AAP registry when the code was created.
+2. **The price is a signed issuance snapshot.** It was accurate according to Rako's registry at the time of issuance.
+3. **The merchant identifier was recorded by Rako.** The code identifies the merchant account associated with the offer at issuance time.
+4. **The commission terms are signed.** They were included in the signed payload and cannot be changed without invalidating the code.
 5. **The code is authentic.** Only Rako's private key could have produced the signature.
 
 ## What the AAP Code Does NOT Guarantee

--- a/spec/v1/commission.md
+++ b/spec/v1/commission.md
@@ -103,10 +103,10 @@ Builders can challenge clawbacks through the dispute process with evidence from 
 Commission is settled monthly, after validation periods close for the relevant transactions.
 
 ### Payment Rails
-Settlement uses standard payment infrastructure:
-- Bank transfer (UK Faster Payments / SEPA)
-- Stripe Connect (for builders with Stripe accounts)
-- Agent-to-agent payment rails (Payman, Orthogonal) as they mature
+Settlement uses standard payout infrastructure:
+- Bank transfer where supported
+- Processor-managed payout accounts where supported
+- Future agent-native payout rails as they mature
 
 ### Minimum Payout
 £25 minimum per settlement. Below threshold, balance carries forward to next period.

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -23,8 +23,8 @@ Agent → POST /v1/purchase { recommendationId }
   ← { checkoutUrl, paymentId }
 
 User → opens checkoutUrl (hosted payment link)
-  → enters card on merchant's PSP-hosted checkout
-  → payment settles to merchant via merchant's PSP
+  → enters card on merchant-processor-hosted checkout
+  → payment settles to merchant via merchant's payment processor
 
 Payment webhook → AAP
   → AAP records conversion after required verification checks pass
@@ -35,8 +35,8 @@ Payment webhook → AAP
 2. AAP creates a hosted payment link on the merchant's connected processor.
 3. AAP embeds the AAP Code in the payment's `metadata.aap_code` field.
 4. The checkout URL is returned to the agent, which presents it to the user.
-5. The user enters payment credentials directly into the PSP-hosted checkout.
-6. Payment settles from buyer → merchant's PSP → merchant. AAP never touches funds.
+5. The user enters payment credentials directly into the merchant-processor-hosted checkout.
+6. In the intended merchant-processor model, payment settles from buyer → merchant's payment processor → merchant. AAP does not receive or control buyer funds.
 7. The payment orchestration layer sends a webhook to AAP with the payment outcome.
 8. AAP records the conversion as **verified** only after the webhook signature, AAP Code signature, metadata payload, amount, and payment status checks pass.
 
@@ -48,7 +48,7 @@ The agent has stored payment credentials and completes the purchase without user
 Agent → POST /v1/purchase { recommendationId, paymentMethod }
   ← { confirmation, paymentId, status }
 
-Payment orchestration layer → processes via merchant's PSP
+Payment orchestration layer → processes via merchant's payment processor
   → webhook to AAP
   → AAP records conversion after required verification checks pass
 ```
@@ -57,7 +57,7 @@ Payment orchestration layer → processes via merchant's PSP
 1. Agent calls `POST /v1/purchase` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
 2. AAP creates a payment intent on the merchant's connected processor and requests confirmation.
 3. AAP Code is embedded in payment metadata.
-4. Payment settles to merchant via merchant's PSP. AAP never touches funds.
+4. In the intended merchant-processor model, payment settles to the merchant via the merchant's payment processor. AAP does not receive or control buyer funds.
 5. Webhook confirms outcome. Conversion is recorded as verified only after the same webhook, AAP Code, payload, amount, and status checks pass.
 
 **Note:** Mode 2 requires the agent to have legitimate stored payment credentials from the user. AAP does not vault or manage user payment credentials.
@@ -74,15 +74,15 @@ Every party in the transaction has an incentive to misreport:
 |-------|-----------|
 | Agent | Wants commission — could fabricate conversions |
 | Merchant | Wants to avoid commission — could deny conversions |
-| Merchant's PSP | No stake in AAP's commission — neutral third party |
+| Merchant's payment processor | No stake in AAP's commission — independent payment evidence source |
 
-The protocol treats the merchant's PSP as the independent evidence source. A payment event is eligible to become a verified conversion only when AAP can authenticate the event source and reconcile the amount, status, recommendation, offer, and signed AAP Code.
+The protocol treats the merchant's payment processor as the independent evidence source. A payment event is eligible to become a verified conversion only when AAP can authenticate the event source and reconcile the amount, status, recommendation, offer, and signed AAP Code.
 
 ### Verification Levels
 
 | Level | Source | Trust | Commission Rate | Settlement Speed |
 |-------|--------|-------|-----------------|------------------|
-| **Verified** | Authenticated PSP payment webhook plus AAP reconciliation checks | Independent payment evidence confirms the payable outcome | Full commission | Standard (after validation period) |
+| **Verified** | Authenticated payment webhook plus AAP reconciliation checks | Independent payment evidence confirms the payable outcome | Full commission | Standard (after validation period) |
 | **Unverified** | Agent callback or merchant self-report | Trust-dependent — requires validation period | Reduced commission (75%) | Delayed (extended validation period) |
 
 **Verified conversions** require an authenticated event from the merchant's payment processor and successful reconciliation against the signed AAP Code, recommendation, offer, amount, and payment status.
@@ -97,21 +97,21 @@ AAP introduces **zero additional payment processing fees**.
 
 | Fee | Who Pays | To Whom |
 |-----|----------|---------|
-| PSP processing fee (e.g., 1.4% + 20p) | Merchant | Merchant's PSP (Stripe, Adyen, etc.) |
+| Payment processing fee (example rate set by processor) | Merchant | Merchant's payment processor |
 | AAP commission (e.g., £8 CPA) | Merchant | AAP (invoiced monthly as B2B receivable) |
 | AAP network fee (20% of commission) | Deducted from commission | AAP retains; remainder to Agent Builder |
 
-The merchant pays exactly the same PSP fees they'd pay without AAP. Commission is a separate invoice, not a deduction from payment funds.
+The merchant pays the same payment-processing fees they would pay without AAP. Commission is a separate invoice, not a deduction from payment funds.
 
 ---
 
-## Merchant Onboarding (OAuth)
+## Merchant Payment Connector Onboarding
 
-Merchants connect their existing PSP account to AAP via OAuth:
+Merchants connect their existing payment processor account to AAP through a scoped connector flow:
 
-1. Merchant clicks **"Connect your Stripe"** on the AAP dashboard.
-2. OAuth flow redirects to Stripe (or Adyen, Worldpay, etc.).
-3. Merchant authorises scoped access (minimum required permissions).
+1. Merchant clicks **"Connect payment processor"** on the AAP dashboard.
+2. The connector flow redirects to the merchant's selected processor or processor-authorisation page.
+3. Merchant authorises scoped access with the minimum required permissions.
 4. AAP stores the authorised connector configuration for the merchant account.
 5. AAP can now create payment links and receive payment events for that merchant account.
 
@@ -125,7 +125,7 @@ Merchants connect their existing PSP account to AAP via OAuth:
 
 ## AAP Code in Payment Metadata
 
-Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
+Every AAP-orchestrated payment embeds the AAP Code in the payment metadata:
 
 ```json
 {
@@ -154,17 +154,17 @@ If any check is missing or fails, the conversion must remain unverified, pending
 
 ## Payment Orchestration Role
 
-AAP uses a payment orchestration layer between AAP and the merchant's PSP. The orchestration layer is **not** itself the merchant's payment processor.
+AAP uses a payment orchestration layer between AAP and the merchant's payment processor. The orchestration layer is **not** itself the merchant's payment processor.
 
-- Does not hold money
-- Does not move money
-- Does not replace the merchant's PSP
+- Does not hold buyer funds
+- Does not become the merchant of record
+- Does not replace the merchant's payment processor
 
 The orchestration layer provides:
 - **One API** for AAP to create payments across supported processors
 - **Payment links** — hosted checkout pages
 - **Webhooks** — unified event format regardless of underlying processor
-- **Connector framework** — merchant connects their PSP once, AAP uses it for eligible transactions
+- **Connector framework** — merchant connects their payment processor once, AAP uses it for eligible transactions
 
 ---
 

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -1,10 +1,14 @@
 # Payment Architecture
 
-> How AAP verifies purchases trustlessly without processing payments.
+> Protocol design for payment-observed attribution without Rako processing customer payments.
+
+## Implementation Status
+
+This document describes the AAP v1 payment architecture and verification requirements. Rako's hosted implementation is still closing the full payment-verification loop: payment webhooks, AAP Code verification on webhook receipt, amount matching, and payload matching must all be implemented and tested before public materials should describe hosted conversions as fully verified, trustless, or tamper-proof.
 
 ## Core Principle
 
-AAP does not process payments. AAP orchestrates payments on the merchant's own payment processor via Hyperswitch. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
+AAP does not process payments. In the designed production model, AAP orchestrates payments on the merchant's own payment processor through a payment orchestration layer. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
 
 ---
 
@@ -18,23 +22,23 @@ The agent recommends. The user completes checkout.
 Agent → POST /v1/purchase { recommendationId }
   ← { checkoutUrl, paymentId }
 
-User → opens checkoutUrl (Hyperswitch payment link)
+User → opens checkoutUrl (hosted payment link)
   → enters card on merchant's PSP-hosted checkout
   → payment settles to merchant via merchant's PSP
 
-Hyperswitch → webhook to AAP
-  → AAP records verified conversion
+Payment webhook → AAP
+  → AAP records conversion after required verification checks pass
 ```
 
 **Flow:**
 1. Agent calls `POST /v1/purchase` with the `recommendationId` from a prior recommendation.
-2. AAP creates a Hyperswitch payment link on the merchant's connected processor.
+2. AAP creates a hosted payment link on the merchant's connected processor.
 3. AAP embeds the AAP Code in the payment's `metadata.aap_code` field.
 4. The checkout URL is returned to the agent, which presents it to the user.
 5. The user enters payment credentials directly into the PSP-hosted checkout.
 6. Payment settles from buyer → merchant's PSP → merchant. AAP never touches funds.
-7. Hyperswitch fires a webhook to AAP confirming the payment outcome.
-8. AAP records the conversion as **verified** (trustless — confirmed by neutral PSP).
+7. The payment orchestration layer sends a webhook to AAP with the payment outcome.
+8. AAP records the conversion as **verified** only after the webhook signature, AAP Code signature, metadata payload, amount, and payment status checks pass.
 
 ### Mode 2 — Agent Autonomous
 
@@ -44,17 +48,17 @@ The agent has stored payment credentials and completes the purchase without user
 Agent → POST /v1/purchase { recommendationId, paymentMethod }
   ← { confirmation, paymentId, status }
 
-Hyperswitch → processes via merchant's PSP
+Payment orchestration layer → processes via merchant's PSP
   → webhook to AAP
-  → AAP records verified conversion
+  → AAP records conversion after required verification checks pass
 ```
 
 **Flow:**
 1. Agent calls `POST /v1/purchase` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
-2. AAP creates a Hyperswitch payment intent and processes it directly.
+2. AAP creates a payment intent on the merchant's connected processor and requests confirmation.
 3. AAP Code is embedded in payment metadata.
 4. Payment settles to merchant via merchant's PSP. AAP never touches funds.
-5. Webhook confirms outcome. Conversion recorded as verified.
+5. Webhook confirms outcome. Conversion is recorded as verified only after the same webhook, AAP Code, payload, amount, and status checks pass.
 
 **Note:** Mode 2 requires the agent to have legitimate stored payment credentials from the user. AAP does not vault or manage user payment credentials.
 
@@ -62,7 +66,7 @@ Hyperswitch → processes via merchant's PSP
 
 ## Verification Model
 
-### Why Trustless Verification Matters
+### Why Independent Payment Verification Matters
 
 Every party in the transaction has an incentive to misreport:
 
@@ -72,16 +76,16 @@ Every party in the transaction has an incentive to misreport:
 | Merchant | Wants to avoid commission — could deny conversions |
 | Merchant's PSP | No stake in AAP's commission — neutral third party |
 
-AAP trusts the PSP. The PSP reports what happened: payment created, succeeded or failed, amount and metadata. This is the same trust model as a bank statement.
+The protocol treats the merchant's PSP as the independent evidence source. A payment event is eligible to become a verified conversion only when AAP can authenticate the event source and reconcile the amount, status, recommendation, offer, and signed AAP Code.
 
 ### Verification Levels
 
 | Level | Source | Trust | Commission Rate | Settlement Speed |
 |-------|--------|-------|-----------------|------------------|
-| **Verified** | Hyperswitch PSP webhook | Trustless — neutral third party confirms payment | Full commission | Standard (after validation period) |
+| **Verified** | Authenticated PSP payment webhook plus AAP reconciliation checks | Independent payment evidence confirms the payable outcome | Full commission | Standard (after validation period) |
 | **Unverified** | Agent callback or merchant self-report | Trust-dependent — requires validation period | Reduced commission (75%) | Delayed (extended validation period) |
 
-**Verified conversions** are confirmed by the merchant's payment processor via Hyperswitch webhook. The processor has no relationship with AAP and no reason to fabricate or hide transactions.
+**Verified conversions** require an authenticated event from the merchant's payment processor and successful reconciliation against the signed AAP Code, recommendation, offer, amount, and payment status.
 
 **Unverified conversions** occur when the purchase happens outside AAP's orchestration (e.g., tracked link fallback). These rely on agent callbacks or merchant reporting and carry a longer validation period and reduced commission.
 
@@ -108,8 +112,8 @@ Merchants connect their existing PSP account to AAP via OAuth:
 1. Merchant clicks **"Connect your Stripe"** on the AAP dashboard.
 2. OAuth flow redirects to Stripe (or Adyen, Worldpay, etc.).
 3. Merchant authorises scoped access (minimum required permissions).
-4. AAP stores the access token as a Hyperswitch connector.
-5. AAP can now create payment links and receive webhooks on the merchant's account.
+4. AAP stores the authorised connector configuration for the merchant account.
+5. AAP can now create payment links and receive payment events for that merchant account.
 
 **Scope restrictions (ENG-08):**
 - Read payment intents and payment methods
@@ -133,31 +137,34 @@ Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
 }
 ```
 
-This is set by AAP when creating the payment via Hyperswitch — not by the agent. The agent cannot modify or forge payment metadata. The PSP stores it alongside the payment record, creating a tamper-proof attribution link.
+This is set by AAP when creating the payment through the payment orchestration layer — not by the agent. The agent cannot modify the metadata AAP sets on that payment object.
 
-On webhook receipt, AAP verifies:
-1. The `aap_code` signature is valid (Ed25519 verification).
-2. The `aap_code` payload matches the recommendation and offer.
-3. The payment amount matches the offer price (within tolerance).
-4. The payment status is `succeeded`.
+For a conversion to be recorded as **verified**, AAP must verify all of the following on webhook receipt:
+1. The payment webhook is authenticated as coming from the configured payment event source.
+2. The `aap_code` signature is valid (Ed25519 verification).
+3. The `aap_code` payload matches the recommendation and offer.
+4. The payment amount matches the offer price (within tolerance).
+5. The payment status is `succeeded`.
 
-If all checks pass, the conversion is recorded as **verified**.
+If any check is missing or fails, the conversion must remain unverified, pending, or rejected according to the implementation's risk policy.
+
+**Hosted implementation note:** these checks are protocol requirements. Public hosted-Rako claims should not describe a payment conversion as fully verified, trustless, or tamper-proof unless the deployed webhook handler implements and tests every check above.
 
 ---
 
-## Hyperswitch's Role
+## Payment Orchestration Role
 
-Hyperswitch is an open-source payment switch. It is **not** a payment processor.
+AAP uses a payment orchestration layer between AAP and the merchant's PSP. The orchestration layer is **not** itself the merchant's payment processor.
 
 - Does not hold money
 - Does not move money
-- Does not compete with Stripe, Adyen, or Worldpay
+- Does not replace the merchant's PSP
 
-Hyperswitch provides:
-- **One API** for AAP to create payments across 275+ processors
+The orchestration layer provides:
+- **One API** for AAP to create payments across supported processors
 - **Payment links** — hosted checkout pages
 - **Webhooks** — unified event format regardless of underlying processor
-- **Connector framework** — merchant connects their PSP once, AAP uses it for all transactions
+- **Connector framework** — merchant connects their PSP once, AAP uses it for eligible transactions
 
 ---
 

--- a/spec/v1/security.md
+++ b/spec/v1/security.md
@@ -65,7 +65,7 @@ This creates a tamper-evident audit trail. Modifying any event breaks the chain 
 
 ### Open Spec, Centralised Trust
 
-AAP uses the same trust model as DNS, Visa, and Stripe:
+AAP uses a familiar open-spec, centralised-operator trust model:
 
 | Layer | Open or Centralised |
 |-------|-------------------|
@@ -99,7 +99,7 @@ The same question comes up every time someone builds a trust layer. The answer f
 - **Speed:** Agent transactions happen in milliseconds. Block confirmation takes seconds to minutes.
 - **Cost:** Per-transaction on-chain fees eat into commissions.
 - **Privacy:** On-chain data is visible. Merchant and builder data must be siloed.
-- **Equivalent guarantee:** Hash-chained signed logs provide the same tamper-evidence without distributed consensus overhead.
+- **Equivalent audit property:** Hash-chained signed logs provide tamper-evidence without distributed consensus overhead.
 
 The trust comes from cryptography, not consensus. Ed25519 signatures are just as unforgeable whether they're stored in a database or on a blockchain.
 
@@ -119,7 +119,7 @@ The trust comes from cryptography, not consensus. Ed25519 signatures are just as
 ### Rate Limiting
 - Per-key rate limits prevent abuse
 - Graduated response: slow down → temporary block → review
-- DDoS protection via Cloudflare
+- Network-level DDoS protections at the edge
 
 ---
 


### PR DESCRIPTION
## Kaneo / issue

Task: `tsk_hn8ZoKm` — Developer docs trust-claims implemented-vs-planned audit.
Internal evidence source: `07-legal-compliance/reviews/2026-04-30-security-trust-blockers-mcp-payment-ledger.md` Blocker 5.

## Summary

- Adds an implementation-status note to the payment architecture spec.
- Reframes verification, trustless, and tamper-proof wording as protocol requirements rather than deployed hosted-Rako guarantees.
- Makes the required verification gate explicit: webhook authentication, AAP Code signature verification, payload match, amount match, and payment status.
- Removes public-facing named payment/payout/infra vendor examples from the spec wording touched by the trust-claims audit.
- Replaces `earn commission` phrasing with attribution-for-eligible-conversions language.

## Compatibility / implementation impact

- No protocol wire-format changes.
- Clarifies that hosted implementations must not call payment conversions fully verified unless the full webhook and reconciliation gate is deployed and tested.
- Backend follow-up remains required for the actual webhook/AAP Code/payment verification implementation.

## Verification

- Spec repo has no package-based validation command.
- Content grep command used:
  - `rg -n "trustless|tamper-proof|verified|go live|production-ready|payment-ready|earn commission|guarantee|guaranteed|processes payment|payment directly|Hyperswitch|Stripe|Adyen|Worldpay|GoCardless|Checkout\\.com|neutral PSP|PSP|Cloudflare|Payman|Orthogonal|Visa" . --glob '!node_modules' --glob '!package-lock.json'`
- Grep result summary:
  - No named internal payment/payout/infra vendor hits remain in `spec/v1` public content.
  - No `earn commission`, `go live`, `production-ready`, or `payment-ready` hits remain.
  - Remaining `trustless`, `tamper-proof`, and `verified` hits are protocol-condition caveats or explicit warnings not to use those claims for hosted Rako until implementation evidence exists.

## Approval / publishing state

- No external publication/release was performed.
- Security & Trust Reviewer coordination requested via ORCH message; approval pending at time of PR update.
- Founder approval is still required before sensitive production payment/trust claims or external activation.


Refs #6
