### PR TITLE
spec: align MCP tools with checkout link flow

### DIFF
--- a/spec/v1/mcp.md
+++ b/spec/v1/mcp.md
@@ -4,7 +4,9 @@
 
 ## Overview
 
-The AAP MCP server exposes three tools that allow any MCP-compatible AI agent to discover offers, make recommendations, and initiate checkout — without writing any code.
+The AAP MCP server exposes three tools that allow an MCP-compatible AI agent to discover offers, check the requirements for a selected offer, and generate a checkout link for the user.
+
+The MCP checkout tool only returns a URL. It does not process payment, charge the user, or transfer money. The user decides whether to open the link and complete checkout.
 
 ## Installation
 
@@ -42,9 +44,9 @@ Search for product offers available through AAP.
 **Output:**
 
 Returns formatted text with:
-- Session ID (needed for recommend and checkout)
+- Session ID, used when generating a checkout link
 - Number of results
-- For each offer: provider, name, price, data, contract, network, 5G, credit check, EU roaming, offer ID
+- For each offer: provider, name, price, data, contract, network, 5G, credit check, EU roaming, and offer ID
 
 **Example interaction:**
 
@@ -52,84 +54,89 @@ Returns formatted text with:
 >
 > **Agent calls** `search_offers({ vertical: "sim", min_data_gb: 10, contract_months: 0 })`
 >
-> **Returns:** 4 offers from SMARTY, giffgaff, VOXI, Lebara with session ID
+> **Returns:** 4 offers from SMARTY, giffgaff, VOXI, Lebara with a session ID
 
-### `recommend`
+### `get_checkout_requirements`
 
-Record a product recommendation and log the attribution event.
+Return the information, confirmations, eligibility checks, and constraints needed before generating checkout for a specific offer.
 
 **Input:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID from search_offers |
-| `offer_id` | string | Yes | ID of the offer to recommend |
-| `context` | string | No | Why this offer was recommended |
+| `offer_id` | string | Yes | Offer ID from `search_offers` |
 
 **Output:**
 
 Returns:
-- Recommendation ID
-- Offer summary (provider, name, price)
-- Fallback URL for drop-off recovery
-- Confirmation that attribution was recorded
+- Required fields or confirmations
+- Eligibility criteria to check with the user
+- Offer-specific constraints
+- Suggested next step before calling `get_checkout_link`
 
 **Example interaction:**
 
-> **Agent:** Based on your needs, I recommend the SMARTY 30GB Rolling Monthly at £10/month. No contract, no credit check, unlimited calls and texts.
+> **Agent:** SMARTY 30GB looks like the best match because it gives you more data at the same price and keeps the rolling monthly terms you asked for.
 >
-> **Agent calls** `recommend({ session_id: "...", offer_id: "...", context: "User wanted cheap SIM, 10GB+, no contract" })`
+> **Agent calls** `get_checkout_requirements({ offer_id: "..." })`
+>
+> **Returns:** any required confirmations and checkout constraints for that offer
 
-### `checkout`
+### `get_checkout_link`
 
-Initiate checkout for a recommended offer.
+Generate a hosted checkout link for the selected offer. This records the attribution context internally and returns a URL the user can open to complete checkout.
+
+This tool does **not** process payment, charge the user, or transfer money. It only generates the checkout link.
 
 **Input:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `session_id` | string | Yes | Session ID from search_offers |
-| `recommendation_id` | string | Yes | Recommendation ID from recommend |
+| `session_id` | string | Yes | Session ID from `search_offers` |
+| `offer_id` | string | Yes | Offer ID the user selected |
+| `context` | string | No | Why this offer was chosen |
 
 **Output:**
 
 Returns:
-- Transaction ID
+- Checkout URL, if generated
 - Status
-- Checkout URL (if applicable)
+- Attribution reference details, when available
 
 **Example interaction:**
 
 > **User:** Yes, I'd like to go with that SMARTY deal.
 >
-> **Agent calls** `checkout({ session_id: "...", recommendation_id: "..." })`
+> **Agent calls** `get_checkout_link({ session_id: "...", offer_id: "...", context: "Best match: 30GB for £10 rolling monthly" })`
 
 ## Full Conversation Flow
 
-```
+```text
 User: I need a new SIM deal. Something cheap, at least 10GB, no contract.
 
 Agent: [calls search_offers(vertical="sim", min_data_gb=10, contract_months=0)]
        I found 4 options for you:
 
        1. SMARTY 30GB — £10/month (Three network, no credit check)
-       2. giffgaff 10GB — £10/month (O2 network, 5G included)  
+       2. giffgaff 10GB — £10/month (O2 network, 5G included)
        3. giffgaff 25GB — £12/month (O2 network, 5G included)
        4. Lebara 5GB — £5/month (Vodafone network)
 
-       I'd recommend the SMARTY 30GB at £10/month — you get 3x the data
-       of the giffgaff 10GB plan at the same price, and no credit check.
-
-       [calls recommend(session_id, offer_id, context="Best value: 30GB for £10")]
+       SMARTY 30GB looks like the best match because it gives you more data
+       at the same price and keeps the rolling monthly terms you asked for.
 
 User: Sounds good, let's go with SMARTY.
 
-Agent: [calls checkout(session_id, recommendation_id)]
-       I've started the checkout process. Here's a link if you'd like to 
-       complete the purchase: https://aap.link/r/...
+Agent: [calls get_checkout_requirements(offer_id)]
+       Before I generate the checkout link, please confirm you're happy with
+       the rolling monthly SIM terms and that you'll complete checkout yourself.
 
-       If you prefer to check it out yourself later, that link will keep 
-       your deal reserved.
+User: Yes, that's fine.
+
+Agent: [calls get_checkout_link(session_id, offer_id, context="Best match: 30GB for £10 rolling monthly")]
+       Here's your checkout link: https://aap.link/r/...
+
+       You can open the link to review the merchant checkout and complete the purchase.
 ```
 
 ## Environment Variables


### PR DESCRIPTION
## Kaneo task / GitHub issue

- Kaneo/ORCH task: Update public MCP docs and spec after backend PR 22

## Summary

- Updated `spec/v1/mcp.md` from the stale `search_offers → recommend → checkout` wording to the canonical public MCP flow: `search_offers → get_checkout_requirements → get_checkout_link`.
- Documented `get_checkout_requirements` inputs/outputs.
- Documented `get_checkout_link` as the checkout-link generation tool that records attribution context internally.
- Added public guardrails that checkout-link generation does not process payment, charge the user, or transfer money.
- Avoided internal vendor names and guaranteed-earnings language in the touched MCP spec page.

## Compatibility notes

- Public MCP clients should call `search_offers`, then `get_checkout_requirements`, then `get_checkout_link`.
- `get_checkout_link` takes `session_id`, `offer_id`, and optional `context`; it no longer asks public MCP users for a separate `recommendation_id`.

## Implementation impact for backend/SDK/docs

- Depends on backend PR 22 aligning stdio MCP with the canonical remote MCP flow.
- Companion developer docs PR: rakohq/developer-docs branch `docs-mcp-canonical-flow`.

## Verification evidence

- Spec repo has no package/doc-check script available.
- Stale-flow/public-guardrail grep on `spec/v1/mcp.md`:
  - no `search_offers → recommend → checkout`
  - no `### recommend` / `### checkout` MCP tool sections
  - no `calls recommend` / `calls checkout`
  - no `earn commission`, `Hyperswitch`, `Stripe`, or `guaranteed`
- Canonical grep confirmed `get_checkout_requirements`, `get_checkout_link`, and "does not process payment / transfer money" guardrail text.

## Deployment / publishing

- No external publishing performed. This PR only prepares spec changes for review.
