### PR TITLE
Spec: clarify checkout evidence boundary

### DIFF
--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -63,12 +63,12 @@ The payment from merchant to agent builder for driving a sale. Calculated based 
                Fallback URL generated for drop-off recovery
 
 3. TRANSACT    User decides to purchase
-               Agent calls checkout() → transaction initiated
-               AAP routes to merchant checkout
+               Agent calls checkout() → hosted checkout handoff created
+               Checkout handoff does not prove conversion
 
-4. CONVERT     Merchant confirms the sale
-               Merchant calls conversions API with order details
-               AAP matches conversion to recommendation
+4. CONVERT     Platform-side outcome evidence arrives
+               Payment, merchant, or milestone evidence is reconciled
+               AAP records a conversion if evidence validates
 
 5. SETTLE      Validation period passes (no cancellation)
                Commission calculated: merchant terms minus 20% network fee
@@ -90,7 +90,7 @@ CREATED → ACTIVE → CHECKOUT → CONVERTED → VALIDATED → SETTLED
 | CREATED | Agent searches for offers |
 | ACTIVE | Agent records a recommendation |
 | CHECKOUT | Agent initiates checkout |
-| CONVERTED | Merchant confirms sale |
+| CONVERTED | Platform-side outcome evidence validates |
 | VALIDATED | Validation period passes without cancellation |
 | SETTLED | Commission paid to builder |
 | CANCELLED | Customer cancels within validation period |
@@ -120,7 +120,7 @@ CREATED → ACTIVE → CHECKOUT → CONVERTED → VALIDATED → SETTLED
 - **[Commission Model](./commission.md)** — Types, floors, calculation, settlement
 - **[API Reference](./api.md)** — REST endpoints
 - **[MCP Integration](./mcp.md)** — MCP tool definitions
-- **[Payment Architecture](./payments.md)** — Payment modes, verification, Hyperswitch integration
+- **[Payment Architecture](./payments.md)** — Checkout handoff, payment evidence, and conversion boundaries
 - **[Security](./security.md)** — Signing, fraud prevention, trust model
 
 ## 8. Versioning

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -4,7 +4,7 @@
 
 ## What It Is
 
-An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes everything needed for attribution in a single, tamper-proof string.
+An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes offer and attribution context in a signed string.
 
 An agent cannot fake one. A merchant cannot self-issue one. A competitor cannot generate one that Rako will honour.
 
@@ -27,7 +27,7 @@ aap://rako.sh/v1/eyJ2IjoiMSIsImlzcyI6InJha28uc2giLCJvZmYiOiIwMUpRWEsxMDAxU01BUlR
 | `iss` | string | Issuer. Always `"rako.sh"`. |
 | `off` | string | Offer ID in the AAP registry. |
 | `mer` | string | Merchant ID in the AAP registry. |
-| `pro` | string | Provider name (e.g. "SMARTY"). |
+| `pro` | string | Provider name (e.g. "Example Mobile"). |
 | `prd` | string | Product name (e.g. "1GB Rolling Monthly"). |
 | `prc` | number | Price (e.g. 6.00). |
 | `cur` | string | Currency code (e.g. "GBP"). |
@@ -42,27 +42,27 @@ aap://rako.sh/v1/eyJ2IjoiMSIsImlzcyI6InJha28uc2giLCJvZmYiOiIwMUpRWEsxMDAxU01BUlR
 
 ## Payment Metadata Embedding
 
-When a purchase is initiated through AAP, the AAP Code is embedded in payment metadata by the AAP platform via Hyperswitch. Agents do **not** manually embed AAP Codes in order notes or descriptions.
+When checkout is initiated through an AAP-controlled server-side path, the AAP Code can be embedded in checkout or payment metadata by platform infrastructure. Agents do **not** manually embed AAP Codes in order notes or descriptions.
 
 ### How It Works
 
-1. Agent calls `POST /v1/purchase` with a `recommendationId`.
-2. AAP creates a payment link/intent on the merchant's PSP via Hyperswitch.
-3. AAP sets the following metadata on the payment object:
+1. Agent or website calls `POST /v1/checkout` with a `sessionId` and `recommendationId`.
+2. AAP validates context and creates a hosted checkout handoff when the integration supports it.
+3. AAP sets the following metadata on the checkout or payment object:
 
 ```json
 {
   "metadata": {
     "aap_code": "aap://rako.sh/v1/{base64url_payload}.{base64url_signature}",
-    "aap_recommendation_id": "01JQXK1001SMARTY1GB000001",
+    "aap_recommendation_id": "01JQXK1001EXAMPLE1GB000001",
     "aap_session_id": "sess_abc123"
   }
 }
 ```
 
-4. The merchant's PSP stores this metadata alongside the payment record.
-5. On payment completion, the PSP webhook delivers the metadata back to AAP.
-6. AAP verifies the `aap_code` signature and matches it to the recommendation.
+4. The checkout or payment system stores this metadata alongside the record.
+5. Later platform-side outcome evidence delivers the metadata back to AAP.
+6. AAP verifies the `aap_code` signature and matches it to the recommendation before recording a conversion.
 
 ### Why Platform-Side Embedding
 
@@ -70,19 +70,19 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 |----------|----------|
 | Agent embeds AAP Code in order notes | Agent can forge or omit codes |
 | Merchant embeds AAP Code at checkout | Merchant can strip codes to avoid commission |
-| **AAP embeds via Hyperswitch** | **Tamper-proof — neither agent nor merchant controls metadata** |
+| Server-side AAP-controlled embedding | Browser or agent clients do not control metadata |
 
-Because AAP creates the payment object through Hyperswitch, the AAP Code is set at creation time. The merchant's PSP stores it as immutable payment metadata. Neither the agent nor the merchant can modify it after creation.
+Because AAP creates the checkout handoff through server-side infrastructure, the AAP Code is set before the buyer enters checkout. Agents and browser clients should not be treated as the authority for attribution, source, conversion, or settlement state.
 
-### Verification on Webhook
+### Verification on outcome evidence
 
-When AAP receives a payment webhook, it:
+When AAP receives platform-side outcome evidence, it:
 
-1. Extracts `metadata.aap_code` from the payment event.
+1. Extracts `metadata.aap_code` from the outcome event.
 2. Verifies the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
 3. Decodes the payload and confirms the offer, merchant, and price match.
-4. Checks the payment amount matches the AAP Code price (within tolerance).
-5. Records the conversion as **verified** if all checks pass.
+4. Checks the amount and currency match the AAP Code price within configured tolerance when relevant.
+5. Records the conversion if all checks pass and the configured conversion flow allows it.
 
 ## Signing
 
@@ -141,7 +141,7 @@ Agent builders and merchants can cache this key and verify AAP Codes independent
 POST /v1/codes/issue
 Authorization: Bearer <api_key>
 
-{ "offerId": "01JQXK1001SMARTY1GB000001" }
+{ "offerId": "01JQXK1001EXAMPLE1GB000001" }
 ```
 
 Response:
@@ -166,7 +166,7 @@ Response (valid):
 {
   "valid": true,
   "issuer": "rako.sh",
-  "offer": { "id": "...", "provider": "SMARTY", "product": "1GB Rolling Monthly", "price": 6, "currency": "GBP" },
+  "offer": { "id": "...", "provider": "Example Mobile", "product": "1GB Rolling Monthly", "price": 6, "currency": "GBP" },
   "commission": { "type": "cpa", "value": 8 },
   "issuedAt": "2026-04-02T08:18:45.000Z",
   "expiresAt": "2026-05-02T08:18:45.000Z"
@@ -181,21 +181,21 @@ Response (invalid):
 }
 ```
 
-## What the AAP Code Guarantees
+## What a valid AAP Code proves
 
 When a valid AAP Code is present:
 
-1. **The offer is real.** It was published by a verified merchant on the AAP registry.
-2. **The price is current.** It was accurate at the time of issuance.
-3. **The merchant is vetted.** They passed Rako's merchant verification.
-4. **The commission terms are immutable.** They were locked at issuance and cannot be altered retroactively.
-5. **The code is authentic.** Only Rako's private key could have produced the signature.
+1. **The code is authentic.** Only Rako's private key could have produced the signature.
+2. **The signed payload was issued by Rako.** Offer, merchant, price, currency, and commission fields match the issued payload.
+3. **The payload has integrity.** Changing the payload invalidates the signature.
+4. **The code has an issuance and expiry time.** Consumers can check whether the code is still inside its validity window.
 
-## What the AAP Code Does NOT Guarantee
+## What a valid AAP Code does not prove
 
 1. **Real-time availability.** The offer may have sold out or expired since issuance. Check the `exp` field.
-2. **Price accuracy at checkout.** For live-pricing verticals (flights, hotels), the price may change. The AAP Code captures the price at discovery, not at checkout.
-3. **Conversion.** Having a code doesn't mean the user will buy.
+2. **Price accuracy at checkout.** For live-pricing verticals, the price may change. The AAP Code captures the price at discovery, not necessarily at checkout.
+3. **Conversion.** Having a code does not mean the user will buy.
+4. **Settlement eligibility.** Conversion and settlement depend on later outcome evidence and validation rules.
 
 ---
 

--- a/spec/v1/api.md
+++ b/spec/v1/api.md
@@ -56,10 +56,10 @@ Search and filter available offers. Automatically creates a session.
   "sessionId": "01KN6KV0TWMH8VS6TDS3S7V2EJ",
   "offers": [
     {
-      "id": "01JQXK1001SMARTY1GB000001",
-      "merchantId": "01JQXK0001SMARTY000000001",
+      "id": "01JQXK1001EXAMPLEOFFER001",
+      "merchantId": "01JQXK0001EXAMPLEMERCH001",
       "vertical": "sim",
-      "provider": "SMARTY",
+      "provider": "Example Mobile",
       "name": "1GB Rolling Monthly",
       "price": 6.00,
       "currency": "GBP",
@@ -95,7 +95,7 @@ Record a recommendation. This is the attribution event.
 ```json
 {
   "sessionId": "01KN6KV0TWMH8VS6TDS3S7V2EJ",
-  "offerId": "01JQXK1001SMARTY1GB000001",
+  "offerId": "01JQXK1001EXAMPLEOFFER001",
   "context": "User asked for the cheapest SIM deal with no contract"
 }
 ```
@@ -114,8 +114,8 @@ Record a recommendation. This is the attribution event.
   "fallbackUrl": "https://aap.link/r/01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
   "attributionRecorded": true,
   "offer": {
-    "id": "01JQXK1001SMARTY1GB000001",
-    "provider": "SMARTY",
+    "id": "01JQXK1001EXAMPLEOFFER001",
+    "provider": "Example Mobile",
     "name": "1GB Rolling Monthly",
     "price": 6.00,
     "currency": "GBP"
@@ -129,7 +129,7 @@ Record a recommendation. This is the attribution event.
 
 #### `POST /v1/checkout`
 
-Initiate checkout for a recommended offer.
+Initiate a server-side hosted checkout handoff for a recommended offer. The checkout response is not conversion proof; conversion requires later platform-side outcome evidence.
 
 **Request Body:**
 
@@ -146,8 +146,8 @@ Initiate checkout for a recommended offer.
 ```json
 {
   "transactionId": "01KN6KWQEENKX01N1TZE3R1TPX",
-  "status": "initiated",
-  "checkoutUrl": "https://merchant.com/checkout?aap_ref=...",
+  "status": "checkout",
+  "checkoutUrl": "https://checkout.example/hosted/abc123",
   "session": { "id": "...", "status": "checkout" }
 }
 ```
@@ -182,7 +182,7 @@ Get session details including recommendations and conversions.
 
 #### `POST /v1/conversions`
 
-Report a completed sale. Called by merchants when a transaction completes.
+Report a completed sale or payable milestone. Called by merchants when merchant-side outcome evidence is available.
 
 **Request Body:**
 
@@ -222,7 +222,7 @@ Report a completed sale. Called by merchants when a transaction completes.
 Issue a signed AAP Code for an offer.
 
 ```json
-{ "offerId": "01JQXK1001SMARTY1GB000001" }
+{ "offerId": "01JQXK1001EXAMPLEOFFER001" }
 ```
 
 #### `POST /v1/codes/verify`

--- a/spec/v1/attribution.md
+++ b/spec/v1/attribution.md
@@ -17,17 +17,17 @@ The agent whose session token is on the transaction gets 100% of the commission.
 - Incentivises agents that complete the full loop (discover → recommend → checkout).
 
 **Example:**
-> User asks Claude about broadband. Claude recommends TalkTalk via AAP. User doesn't buy. Next day, user asks ChatGPT about broadband. ChatGPT recommends TalkTalk via AAP. User buys through ChatGPT.
+> User asks Agent A about broadband. Agent A recommends an Example Broadband offer via AAP. User doesn't buy. Next day, user asks Agent B about broadband. Agent B recommends the same offer via AAP. User buys through Agent B's valid AAP flow.
 >
-> **Result:** ChatGPT's builder gets paid. Claude's builder doesn't. Claude's session expired.
+> **Result:** Agent B's builder is attributed. Agent A's expired session is not attributed.
 
 ### Rule 2 — Single-Agent Drop-Off: Fallback Chain
 
-When an agent recommends a product and the user doesn't buy through the agent flow, the recommending agent can still earn — at reduced rates — through the drop-off recovery chain.
+When an agent recommends a product and the user does not continue through the agent checkout flow, fallback paths can preserve lower-confidence attribution context if the merchant configuration supports it.
 
 | Priority | Conversion Path | Commission Rate | Mechanism |
 |----------|----------------|-----------------|-----------|
-| **Best** | AAP flow (user buys through agent) | Full rate | Session-based attribution |
+| **Best** | AAP flow (user reaches checkout through accepted agent context) | Full rate | Session-based attribution plus later conversion evidence |
 | **Good** | Tracked link (user clicks `aap.link/r/...`) | 75% of full rate | Cookie/UTM via redirect |
 | **Okay** | Browser extension (catches user on merchant site) | 75% of full rate | Extension activates tracking |
 | **Last** | Influence attribution (data-matched) | 50% of full rate or flat fee | Temporal + product matching |
@@ -55,7 +55,7 @@ When a user clicks this URL:
 5. Redirects (302) to the merchant's product page
 6. Logs the click event
 
-If the user purchases within the 30-day cookie window, the conversion is attributed to the original recommending agent at the tracked link commission rate.
+If later merchant or payment evidence validates a payable outcome within the configured window, the conversion can be attributed to the original recommending agent at the tracked-link rate.
 
 ## Attribution Window
 
@@ -90,17 +90,17 @@ When `recommend()` is called, the following attribution event is created:
 - Multiple paths claim the same conversion
 
 ### Resolution
-Disputes are resolved using the cryptographically signed event chain. Every event (search, recommendation, click, conversion) is logged with timestamps and agent identity. AAP arbitrates based on this evidence.
+Disputes are resolved using the recorded event chain. Events such as search, recommendation, click, checkout handoff, and conversion are logged with timestamps and actor identity. AAP evaluates disputes against this evidence and the merchant's configured validation rules.
 
 ### Priority Order
 If a conversion could be attributed via multiple paths (e.g., both AAP flow and tracked link), the highest-priority path wins:
 
-1. AAP flow (session-based) — always takes precedence
+1. AAP flow (session-based recommendation plus later conversion evidence) — highest priority
 2. Tracked link — takes precedence over extension and influence
 3. Browser extension — takes precedence over influence
 4. Influence matching — lowest priority
 
-Duplicate attribution is prevented. One conversion = one commission payment.
+Duplicate attribution should be prevented. One accepted conversion maps to one commission path.
 
 ---
 

--- a/spec/v1/commission.md
+++ b/spec/v1/commission.md
@@ -4,7 +4,7 @@
 
 ## Commission Types
 
-Merchants choose their commission structure when they join AAP:
+Merchants choose their commission structure when their offers are configured for AAP:
 
 | Type | Description | Example |
 |------|-------------|---------|
@@ -27,8 +27,8 @@ To prevent a race to the bottom, AAP enforces minimum commission floors per vert
 
 Floors are reviewed quarterly and adjusted based on:
 - Industry benchmark commission rates (Awin, CJ, Impact data)
-- Agent builder feedback (are rates high enough to justify integration?)
-- Merchant acquisition needs (are floors blocking merchant signups?)
+- Agent builder feedback
+- Merchant configuration needs
 
 ## Network Fee
 
@@ -40,12 +40,12 @@ Gross commission (merchant pays)
   × 0.20 = AAP network fee
 
 Example:
-  SMARTY CPA: £8.00
+  Example Mobile CPA: £8.00
   Builder receives: £6.40
   AAP receives: £1.60
 ```
 
-The network fee is non-negotiable for standard tiers. Enterprise merchants (post-2028) may negotiate volume-based discounts (15-18%).
+The network fee is non-negotiable for standard tiers. Different commercial tiers may have different network-fee terms if configured by Rako.
 
 ## Commission by Conversion Path
 
@@ -90,7 +90,7 @@ After validation:
 
 | Event | During Validation | After Validation |
 |-------|------------------|-----------------|
-| Customer cancels | Commission clawed back | Merchant absorbs |
+| Customer cancels | Commission clawed back | Handled by merchant policy |
 | Chargeback | Commission reversed | Commission reversed |
 | Fraud detected | Commission rejected | Commission clawed back + builder flagged |
 | Merchant disputes | Under review | Under review |
@@ -105,8 +105,7 @@ Commission is settled monthly, after validation periods close for the relevant t
 ### Payment Rails
 Settlement uses standard payment infrastructure:
 - Bank transfer (UK Faster Payments / SEPA)
-- Stripe Connect (for builders with Stripe accounts)
-- Agent-to-agent payment rails (Payman, Orthogonal) as they mature
+- Supported payout providers or account-to-account rails where configured
 
 ### Minimum Payout
 £25 minimum per settlement. Below threshold, balance carries forward to next period.
@@ -115,7 +114,7 @@ Settlement uses standard payment infrastructure:
 
 ### CPA (SIM deal)
 ```
-Merchant: SMARTY
+Merchant: Example Mobile
 Commission type: CPA
 Commission value: £8.00
 Conversion path: AAP flow (100%)
@@ -127,7 +126,7 @@ Builder payout: £6.40
 
 ### Percentage (Flight)
 ```
-Merchant: British Airways
+Merchant: Example Travel
 Commission type: Percentage
 Commission value: 5%
 Transaction value: £189.00
@@ -140,7 +139,7 @@ Builder payout: £7.56
 
 ### Hybrid (Insurance)
 ```
-Merchant: Aviva
+Merchant: Example Insurance
 Commission type: Hybrid
 Commission min: £15.00
 Commission value: 3%

--- a/spec/v1/mcp.md
+++ b/spec/v1/mcp.md
@@ -52,7 +52,7 @@ Returns formatted text with:
 >
 > **Agent calls** `search_offers({ vertical: "sim", min_data_gb: 10, contract_months: 0 })`
 >
-> **Returns:** 4 offers from SMARTY, giffgaff, VOXI, Lebara with session ID
+> **Returns:** 4 offers from Example Mobile, Example SIM, Example 5G, Example Lite with session ID
 
 ### `recommend`
 
@@ -76,7 +76,7 @@ Returns:
 
 **Example interaction:**
 
-> **Agent:** Based on your needs, I recommend the SMARTY 30GB Rolling Monthly at £10/month. No contract, no credit check, unlimited calls and texts.
+> **Agent:** Based on your needs, I recommend the Example Mobile 30GB Rolling Monthly at £10/month. No contract, no credit check, unlimited calls and texts.
 >
 > **Agent calls** `recommend({ session_id: "...", offer_id: "...", context: "User wanted cheap SIM, 10GB+, no contract" })`
 
@@ -100,7 +100,7 @@ Returns:
 
 **Example interaction:**
 
-> **User:** Yes, I'd like to go with that SMARTY deal.
+> **User:** Yes, I'd like to go with that Example Mobile deal.
 >
 > **Agent calls** `checkout({ session_id: "...", recommendation_id: "..." })`
 
@@ -112,24 +112,23 @@ User: I need a new SIM deal. Something cheap, at least 10GB, no contract.
 Agent: [calls search_offers(vertical="sim", min_data_gb=10, contract_months=0)]
        I found 4 options for you:
 
-       1. SMARTY 30GB — £10/month (Three network, no credit check)
-       2. giffgaff 10GB — £10/month (O2 network, 5G included)  
-       3. giffgaff 25GB — £12/month (O2 network, 5G included)
-       4. Lebara 5GB — £5/month (Vodafone network)
+       1. Example Mobile 30GB — £10/month (Three network, no credit check)
+       2. Example SIM 10GB — £10/month (O2 network, 5G included)
+       3. Example SIM 25GB — £12/month (O2 network, 5G included)
+       4. Example Lite 5GB — £5/month (Vodafone network)
 
-       I'd recommend the SMARTY 30GB at £10/month — you get 3x the data
-       of the giffgaff 10GB plan at the same price, and no credit check.
+       I'd recommend the Example Mobile 30GB at £10/month — you get 3x the data
+       of the Example SIM 10GB plan at the same price, and no credit check.
 
        [calls recommend(session_id, offer_id, context="Best value: 30GB for £10")]
 
-User: Sounds good, let's go with SMARTY.
+User: Sounds good, let's go with Example Mobile.
 
 Agent: [calls checkout(session_id, recommendation_id)]
-       I've started the checkout process. Here's a link if you'd like to 
-       complete the purchase: https://aap.link/r/...
+       I've created a checkout handoff. Here's the hosted checkout link if you'd like to continue: https://aap.link/r/...
 
        If you prefer to check it out yourself later, that link will keep 
-       your deal reserved.
+       the recommendation context available for the configured attribution window.
 ```
 
 ## Environment Variables

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -1,164 +1,129 @@
-# Payment Architecture
+# Payment and Checkout Architecture
 
-> How AAP verifies purchases trustlessly without processing payments.
+> How AAP carries recommendation context into checkout and reconciles conversion evidence later.
 
-## Core Principle
+## Core principle
 
-AAP does not process payments. AAP orchestrates payments on the merchant's own payment processor via Hyperswitch. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
+AAP does not require agents or browsers to process payments, define attribution state, or decide whether a conversion occurred. Checkout creation is a handoff boundary: a server-side request can create a hosted checkout URL, and later platform-side outcome evidence determines whether a conversion should be recorded.
+
+Implementations may use a payment orchestration layer, a merchant's payment processor, or merchant-reported outcome feeds. These are implementation choices, not protocol-level promises.
 
 ---
 
-## Payment Modes
+## Checkout handoff
 
-### Mode 1 — User Checkout (Default)
+### User checkout
 
-The agent recommends. The user completes checkout.
+The common path is a user-facing hosted checkout handoff:
 
-```
-Agent → POST /v1/purchase { recommendationId }
-  ← { checkoutUrl, paymentId }
+```text
+Agent or website → POST /v1/checkout { sessionId, recommendationId }
+  ← { checkoutUrl, transactionId, status }
 
-User → opens checkoutUrl (Hyperswitch payment link)
-  → enters card on merchant's PSP-hosted checkout
-  → payment settles to merchant via merchant's PSP
+Buyer → opens checkoutUrl
+  → completes the merchant checkout journey
 
-Hyperswitch → webhook to AAP
-  → AAP records verified conversion
-```
-
-**Flow:**
-1. Agent calls `POST /v1/purchase` with the `recommendationId` from a prior recommendation.
-2. AAP creates a Hyperswitch payment link on the merchant's connected processor.
-3. AAP embeds the AAP Code in the payment's `metadata.aap_code` field.
-4. The checkout URL is returned to the agent, which presents it to the user.
-5. The user enters payment credentials directly into the PSP-hosted checkout.
-6. Payment settles from buyer → merchant's PSP → merchant. AAP never touches funds.
-7. Hyperswitch fires a webhook to AAP confirming the payment outcome.
-8. AAP records the conversion as **verified** (trustless — confirmed by neutral PSP).
-
-### Mode 2 — Agent Autonomous
-
-The agent has stored payment credentials and completes the purchase without user interaction.
-
-```
-Agent → POST /v1/purchase { recommendationId, paymentMethod }
-  ← { confirmation, paymentId, status }
-
-Hyperswitch → processes via merchant's PSP
-  → webhook to AAP
-  → AAP records verified conversion
+Payment or merchant system → outcome evidence to AAP
+  → AAP records a conversion if evidence validates
 ```
 
 **Flow:**
-1. Agent calls `POST /v1/purchase` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
-2. AAP creates a Hyperswitch payment intent and processes it directly.
-3. AAP Code is embedded in payment metadata.
-4. Payment settles to merchant via merchant's PSP. AAP never touches funds.
-5. Webhook confirms outcome. Conversion recorded as verified.
 
-**Note:** Mode 2 requires the agent to have legitimate stored payment credentials from the user. AAP does not vault or manage user payment credentials.
+1. An agent records a recommendation and receives a `recommendationId`.
+2. A server-side checkout request sends the `sessionId` and `recommendationId` to AAP.
+3. AAP validates the recommendation context and creates a hosted checkout link when the integration supports it.
+4. The checkout URL is returned as a handoff for the buyer.
+5. The buyer completes the checkout journey outside the agent's control.
+6. A payment webhook, merchant report, or configured milestone later provides platform-side outcome evidence.
+7. AAP records the conversion only if the evidence validates against the recommendation and offer context.
 
----
+The checkout URL does not by itself prove payment, order acceptance, commission eligibility, or settlement eligibility.
 
-## Verification Model
+### Autonomous or stored-payment flows
 
-### Why Trustless Verification Matters
+Some integrations may support an agent-initiated payment attempt with a legitimate stored payment method. In those flows, the same boundary still applies: the request may start a payment attempt, but conversion recording depends on later outcome evidence from the payment or merchant system.
 
-Every party in the transaction has an incentive to misreport:
-
-| Party | Incentive |
-|-------|-----------|
-| Agent | Wants commission — could fabricate conversions |
-| Merchant | Wants to avoid commission — could deny conversions |
-| Merchant's PSP | No stake in AAP's commission — neutral third party |
-
-AAP trusts the PSP. The PSP reports what happened: payment created, succeeded or failed, amount and metadata. This is the same trust model as a bank statement.
-
-### Verification Levels
-
-| Level | Source | Trust | Commission Rate | Settlement Speed |
-|-------|--------|-------|-----------------|------------------|
-| **Verified** | Hyperswitch PSP webhook | Trustless — neutral third party confirms payment | Full commission | Standard (after validation period) |
-| **Unverified** | Agent callback or merchant self-report | Trust-dependent — requires validation period | Reduced commission (75%) | Delayed (extended validation period) |
-
-**Verified conversions** are confirmed by the merchant's payment processor via Hyperswitch webhook. The processor has no relationship with AAP and no reason to fabricate or hide transactions.
-
-**Unverified conversions** occur when the purchase happens outside AAP's orchestration (e.g., tracked link fallback). These rely on agent callbacks or merchant reporting and carry a longer validation period and reduced commission.
+AAP does not require agents to vault or manage user payment credentials.
 
 ---
 
-## Fee Structure
+## Evidence model
 
-AAP introduces **zero additional payment processing fees**.
+AAP separates recommendation evidence, checkout handoff, conversion evidence, and settlement eligibility.
 
-| Fee | Who Pays | To Whom |
-|-----|----------|---------|
-| PSP processing fee (e.g., 1.4% + 20p) | Merchant | Merchant's PSP (Stripe, Adyen, etc.) |
-| AAP commission (e.g., £8 CPA) | Merchant | AAP (invoiced monthly as B2B receivable) |
-| AAP network fee (20% of commission) | Deducted from commission | AAP retains; remainder to Agent Builder |
+| Stage | What it means | What it does not prove |
+|-------|---------------|------------------------|
+| Recommendation | An agent recorded offer context for a session. | That the buyer purchased. |
+| Checkout handoff | A hosted checkout or purchase path was created. | That payment succeeded or commission is owed. |
+| Conversion evidence | A payment, merchant, or milestone event was reconciled. | That settlement is final. |
+| Settlement eligibility | Validation, refund, dispute, and clawback rules have been applied. | That future clawbacks are impossible. |
 
-The merchant pays exactly the same PSP fees they'd pay without AAP. Commission is a separate invoice, not a deduction from payment funds.
+### Verification levels
 
----
+| Level | Source | Trust model | Settlement handling |
+|-------|--------|-------------|---------------------|
+| Payment-observed | Payment processor or payment orchestration webhook | Platform-side payment evidence reconciled with AAP context | Subject to validation, refund, dispute, and clawback windows |
+| Merchant-reported | Merchant reports an order, application, policy, activation, or other payable milestone | Merchant system evidence reconciled with AAP context | Subject to configured validation rules |
+| Lower-confidence fallback | Redirect, tracked link, extension, or matching signal | Requires additional validation | May settle differently by merchant configuration |
 
-## Merchant Onboarding (OAuth)
-
-Merchants connect their existing PSP account to AAP via OAuth:
-
-1. Merchant clicks **"Connect your Stripe"** on the AAP dashboard.
-2. OAuth flow redirects to Stripe (or Adyen, Worldpay, etc.).
-3. Merchant authorises scoped access (minimum required permissions).
-4. AAP stores the access token as a Hyperswitch connector.
-5. AAP can now create payment links and receive webhooks on the merchant's account.
-
-**Scope restrictions (ENG-08):**
-- Read payment intents and payment methods
-- Create payment links / checkout sessions
-- Receive webhooks
-- **Excluded:** payouts, transfers, balance reads, bank account access
+Do not treat browser-supplied parameters, completion-page display, direct website traffic, or `website_direct` classification as agent attribution evidence.
 
 ---
 
-## AAP Code in Payment Metadata
+## Fees and settlement
 
-Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
+AAP commission is separate from the merchant's payment processing fees. Payment processing fees remain between the merchant and its payment processor. AAP settlement logic uses conversion evidence and the merchant's configured commercial terms to calculate commission, network fee, and builder payout.
+
+The protocol does not require commission to be deducted from payment funds. Settlement can happen through invoice, payout, or other merchant-configured settlement processes.
+
+---
+
+## Merchant checkout setup
+
+Merchants may connect checkout and outcome reporting in different ways:
+
+1. Use a hosted checkout or payment orchestration integration.
+2. Send payment webhooks or normalized payment events that include AAP context.
+3. Report merchant-side order, application, activation, policy, or first-bill milestones.
+4. Reconcile refunds, disputes, cancellations, clawbacks, and validation windows.
+
+Any implementation should use least-privilege access and should not expose API keys, webhook secrets, processor credentials, or environment-specific URLs in public docs or client-side code.
+
+---
+
+## AAP Code in checkout metadata
+
+When checkout is created by an AAP-controlled backend path, AAP context can be attached to the payment or checkout record:
 
 ```json
 {
   "metadata": {
     "aap_code": "aap://rako.sh/v1/{base64url_payload}.{base64url_signature}",
-    "aap_recommendation_id": "01JQXK1001SMARTY1GB000001",
-    "aap_session_id": "sess_abc123"
+    "aap_recommendation_id": "01KN6KWQDZ6Y5HPW8KFSDPKNSQ",
+    "aap_session_id": "01KN6KV0TWMH8VS6TDS3S7V2EJ"
   }
 }
 ```
 
-This is set by AAP when creating the payment via Hyperswitch — not by the agent. The agent cannot modify or forge payment metadata. The PSP stores it alongside the payment record, creating a tamper-proof attribution link.
+This metadata should be set by server-side infrastructure, not by the browser or agent client. On outcome receipt, AAP can validate:
 
-On webhook receipt, AAP verifies:
-1. The `aap_code` signature is valid (Ed25519 verification).
-2. The `aap_code` payload matches the recommendation and offer.
-3. The payment amount matches the offer price (within tolerance).
-4. The payment status is `succeeded`.
+1. The `aap_code` signature is valid.
+2. The payload matches the recommendation and offer.
+3. The amount and currency match the offer within configured tolerance.
+4. The outcome status is eligible for the configured conversion flow.
 
-If all checks pass, the conversion is recorded as **verified**.
-
----
-
-## Hyperswitch's Role
-
-Hyperswitch is an open-source payment switch. It is **not** a payment processor.
-
-- Does not hold money
-- Does not move money
-- Does not compete with Stripe, Adyen, or Worldpay
-
-Hyperswitch provides:
-- **One API** for AAP to create payments across 275+ processors
-- **Payment links** — hosted checkout pages
-- **Webhooks** — unified event format regardless of underlying processor
-- **Connector framework** — merchant connects their PSP once, AAP uses it for all transactions
+If checks pass, AAP can record a conversion in the ledger. Validation, refund, dispute, and clawback rules still apply before settlement.
 
 ---
 
-*AAP Protocol Spec v1 — Payment Architecture*
+## Implementation notes
+
+- Hosted checkout is a handoff, not conversion proof.
+- Conversion requires later platform-side outcome evidence.
+- Agents and browsers should not construct attribution, source, conversion, or settlement state.
+- Direct website fallback is not agent attribution evidence.
+- Payment orchestration and processor integrations are implementation details, not protocol promises.
+
+---
+
+*AAP Protocol Spec v1 — Payment and Checkout Architecture*

--- a/spec/v1/security.md
+++ b/spec/v1/security.md
@@ -27,7 +27,9 @@ Every event in the attribution chain is logged with:
 - Event type (search, recommend, click, checkout, conversion)
 - Reference to previous event (hash chain)
 
-This creates a tamper-evident audit trail. Modifying any event breaks the chain for all subsequent events.
+Checkout source and conversion state should be derived server-side from accepted context and platform-side outcome evidence. Browser-edited parameters, completion-page display, direct website fallback, or `website_direct` classification are not agent attribution evidence.
+
+This creates a tamper-evident audit trail. Modifying a recorded event should be detectable because subsequent events reference the earlier chain state.
 
 ## Fraud Prevention
 
@@ -38,8 +40,8 @@ This creates a tamper-evident audit trail. Modifying any event breaks the chain 
 | **Session stuffing** | Agent creates thousands of sessions hoping some convert | Rate limiting per agent/builder. Conversion rate floors. |
 | **Identity spoofing** | Agent claims to be a different registered agent | Cryptographic identity via API key. Signed session tokens. |
 | **Commission hijacking** | Agent intercepts another agent's session | Session tokens bound to originating agent. Non-transferable. |
-| **Fake conversions** | Agent simulates a transaction | Merchant-side confirmation required. No self-reporting. |
-| **Self-dealing** | Builder creates fake users | User verification required (phone, email, payment method). |
+| **Fake conversions** | Agent simulates a transaction | Platform-side outcome evidence required. Agent self-reporting is not sufficient. |
+| **Self-dealing** | Builder creates fake users | Configured merchant, payment, or milestone validation controls. |
 | **Churning** | Agent signs up users who immediately cancel | Validation periods + clawback. High churn → builder flagged. |
 | **Click fraud** | Automated clicks on fallback links | IP deduplication, rate limiting, bot detection on redirect service. |
 
@@ -58,14 +60,14 @@ This creates a tamper-evident audit trail. Modifying any event breaks the chain 
 |----------|--------|
 | Suspicious | Flag for review. Continue paying. |
 | Probable fraud | Pause payouts. Manual review. |
-| Confirmed fraud | Suspend builder. Claw back all pending commission. |
+| Confirmed fraud | Suspend builder and apply configured clawback policy. |
 | Repeat offender | Permanent ban. Report to fraud databases. |
 
 ## Trust Model
 
 ### Open Spec, Centralised Trust
 
-AAP uses the same trust model as DNS, Visa, and Stripe:
+AAP uses an open-spec, centrally operated trust model:
 
 | Layer | Open or Centralised |
 |-------|-------------------|
@@ -99,9 +101,9 @@ The same question comes up every time someone builds a trust layer. The answer f
 - **Speed:** Agent transactions happen in milliseconds. Block confirmation takes seconds to minutes.
 - **Cost:** Per-transaction on-chain fees eat into commissions.
 - **Privacy:** On-chain data is visible. Merchant and builder data must be siloed.
-- **Equivalent guarantee:** Hash-chained signed logs provide the same tamper-evidence without distributed consensus overhead.
+- **Equivalent integrity goal:** Hash-chained signed logs can provide tamper-evidence without distributed consensus overhead.
 
-The trust comes from cryptography, not consensus. Ed25519 signatures are just as unforgeable whether they're stored in a database or on a blockchain.
+The trust model uses cryptographic signatures and auditable records rather than distributed consensus.
 
 ## API Security
 
@@ -119,7 +121,7 @@ The trust comes from cryptography, not consensus. Ed25519 signatures are just as
 ### Rate Limiting
 - Per-key rate limits prevent abuse
 - Graduated response: slow down → temporary block → review
-- DDoS protection via Cloudflare
+- DDoS protection at the edge
 
 ---
 


### PR DESCRIPTION
## Kaneo / ORCH task

- Goal: `goal_gclNuiH`
- Task: `tsk_gTAwtUm` — Implement neutral checkout-boundary docs/spec/SDK wording from v3 plan

## Summary

- Rewrites payment architecture around checkout handoff vs later conversion evidence.
- Removes public vendor names and vendor-specific proof language from scanned spec files.
- Replaces trustless/tamper-proof/guarantee wording with implementation-neutral verification language.
- Clarifies that direct website fallback / `website_direct` is not agent attribution evidence.

## Compatibility / implementation impact

- Protocol wording only; no API implementation changes.
- Keeps `/v1/checkout` as the canonical checkout handoff path.
- Does not document legacy direct-provider routes or internal return-source token internals.

## Verification

- Public guardrail scan over `README.md spec` for blocked vendor/readiness/guarantee phrases → no matches.
- `git diff --check` → clean.

## Activation / publishing notes

Draft PR only. Do not publish, tag, release, or externally activate until Product/Security/Founder approval and final onboarding QA gates clear.


Refs #6
