### PR TITLE
Neutralize public payment vendor and trust claims

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -174,7 +174,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Rako Ltd
+   Copyright 2026 RAKO HQ LTD
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ AAP defines how AI agents discover offers, record recommendations, and earn comm
 
 ```python
 # Python
-from aap import AAP
+from agent_attribution_protocol import AAP
+
 aap = AAP(api_key="your-key")
 offers = aap.search(vertical="sim", max_price=10)
 rec = aap.recommend(offers[0], context="user asked for cheap SIM")
@@ -60,8 +61,8 @@ AAP replaces the entire chain with one principle: **the transaction flows throug
 
 This specification is published under the [Apache 2.0 licence](./LICENCE).
 
-"Agent Attribution Protocol" is a trademark of Rako Ltd (UK00004367937).
+Trademark notice: "Agent Attribution Protocol" is the subject of UK trademark application UK00004367937. Check the current UKIPO record for live status and owner details before relying on this notice.
 
 ---
 
-*Rako Ltd — [rako.sh](https://rako.sh)*
+*RAKO HQ LTD (Company No. 17132612) — [rako.sh](https://rako.sh)*

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -29,9 +29,9 @@ AI systems (Claude, ChatGPT, custom agents) that recommend products to users on 
 The entity that operates the AAP infrastructure:
 - Issues and signs AAP Codes
 - Operates the offer registry
-- Verifies merchants and agents
+- Runs merchant and agent registration checks
 - Matches recommendations to conversions
-- Calculates and settles commission
+- Administers commission calculation and settlement according to applicable terms
 - Provides fraud detection
 
 ## 3. Core Concepts
@@ -49,7 +49,7 @@ An attribution event. When an agent calls `recommend()`, it records who recommen
 A completed transaction. When a user purchases a recommended product, the merchant reports the conversion. AAP matches it to the original recommendation.
 
 ### Commission
-The payment from merchant to agent builder for driving a sale. Calculated based on merchant-defined terms, minus the 20% network fee.
+The payment from merchant to agent builder for driving a sale. Calculated based on merchant-defined terms and the applicable network fee schedule; examples in this spec use a 20% network-fee model for illustration unless otherwise agreed.
 
 ## 4. The Attribution Flow
 
@@ -71,7 +71,7 @@ The payment from merchant to agent builder for driving a sale. Calculated based 
                AAP matches conversion to recommendation
 
 5. SETTLE      Validation period passes (no cancellation)
-               Commission calculated: merchant terms minus 20% network fee
+               Commission calculated under merchant terms and applicable network-fee schedule
                Builder receives payout
 ```
 
@@ -132,4 +132,4 @@ Current version: **v1.0.0**
 ---
 
 *AAP Specification v1.0.0 — Published 2 April 2026*
-*Rako Ltd — [rako.sh](https://rako.sh)*
+*RAKO HQ LTD (Company No. 17132612) — [rako.sh](https://rako.sh)*

--- a/spec/v1/README.md
+++ b/spec/v1/README.md
@@ -120,7 +120,7 @@ CREATED → ACTIVE → CHECKOUT → CONVERTED → VALIDATED → SETTLED
 - **[Commission Model](./commission.md)** — Types, floors, calculation, settlement
 - **[API Reference](./api.md)** — REST endpoints
 - **[MCP Integration](./mcp.md)** — MCP tool definitions
-- **[Payment Architecture](./payments.md)** — Payment modes, verification, Hyperswitch integration
+- **[Payment Architecture](./payments.md)** — Payment modes, checkout handoff, and conversion evidence
 - **[Security](./security.md)** — Signing, fraud prevention, trust model
 
 ## 8. Versioning

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -76,13 +76,13 @@ Because AAP associates the AAP Code with the checkout handoff, later outcome evi
 
 ### Verification on Webhook
 
-When AAP receives a payment webhook, it:
+A production payment-outcome verification path is expected to apply these checks when a supported checkout or reporting path returns AAP attribution context. This describes required production verification behavior, not a claim that every current checkout or webhook path already performs these checks live.
 
-1. Extracts `metadata.aap_code` from the payment event.
-2. Verifies the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
-3. Decodes the payload and confirms the offer, merchant, and price match.
-4. Checks the payment amount matches the AAP Code price (within tolerance).
-5. Records the conversion state supported by the evidence if all applicable checks pass.
+1. Extract `metadata.aap_code` or the equivalent AAP attribution field from the authenticated outcome event or merchant report.
+2. Verify the Ed25519 signature against the current Rako public key.
+3. Decode the payload and confirm the offer, merchant, and signed pricing context match the recommendation record.
+4. Check the paid amount and currency against the AAP Code and applicable tolerance rules for the vertical or agreement.
+5. Record only the conversion state supported by the available evidence if all applicable checks pass.
 
 ## Signing
 

--- a/spec/v1/aap-code.md
+++ b/spec/v1/aap-code.md
@@ -4,9 +4,9 @@
 
 ## What It Is
 
-An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes everything needed for attribution in a single, tamper-proof string.
+An AAP Code is a cryptographically signed token issued by Rako for every offer. It encodes the attribution fields needed to verify that a recommendation refers to a registry offer issued by Rako.
 
-An agent cannot fake one. A merchant cannot self-issue one. A competitor cannot generate one that Rako will honour.
+An agent cannot forge a valid signature. A merchant cannot self-issue a valid Rako code. A competitor cannot generate one that Rako will honour.
 
 ## Format
 
@@ -42,13 +42,13 @@ aap://rako.sh/v1/eyJ2IjoiMSIsImlzcyI6InJha28uc2giLCJvZmYiOiIwMUpRWEsxMDAxU01BUlR
 
 ## Payment Metadata Embedding
 
-When a purchase is initiated through AAP, the AAP Code is embedded in payment metadata by the AAP platform via Hyperswitch. Agents do **not** manually embed AAP Codes in order notes or descriptions.
+When a checkout handoff is initiated through AAP, the AAP Code is associated with platform-side attribution context by AAP or its payment orchestration layer where the checkout path supports it. Agents do **not** manually embed AAP Codes in order notes or descriptions.
 
 ### How It Works
 
-1. Agent calls `POST /v1/purchase` with a `recommendationId`.
-2. AAP creates a payment link/intent on the merchant's PSP via Hyperswitch.
-3. AAP sets the following metadata on the payment object:
+1. Agent calls `POST /v1/checkout` with a `recommendationId`.
+2. AAP creates or returns a hosted checkout link for the merchant's configured checkout path.
+3. AAP associates the following attribution context with the checkout or payment object where supported:
 
 ```json
 {
@@ -60,19 +60,19 @@ When a purchase is initiated through AAP, the AAP Code is embedded in payment me
 }
 ```
 
-4. The merchant's PSP stores this metadata alongside the payment record.
-5. On payment completion, the PSP webhook delivers the metadata back to AAP.
+4. The merchant or payment provider stores this context where the checkout path supports metadata.
+5. On payment completion, an authenticated outcome event or merchant report delivers the relevant attribution context back to AAP.
 6. AAP verifies the `aap_code` signature and matches it to the recommendation.
 
 ### Why Platform-Side Embedding
 
 | Approach | Problem |
 |----------|----------|
-| Agent embeds AAP Code in order notes | Agent can forge or omit codes |
-| Merchant embeds AAP Code at checkout | Merchant can strip codes to avoid commission |
-| **AAP embeds via Hyperswitch** | **Tamper-proof — neither agent nor merchant controls metadata** |
+| Agent embeds AAP Code in order notes | Agent can omit codes or include unverifiable text |
+| Merchant embeds AAP Code at checkout | Merchant-side handling can be inconsistent across checkout systems |
+| **AAP associates the code in platform-side attribution context** | **AAP can reconcile the checkout outcome against the signed code and recommendation record** |
 
-Because AAP creates the payment object through Hyperswitch, the AAP Code is set at creation time. The merchant's PSP stores it as immutable payment metadata. Neither the agent nor the merchant can modify it after creation.
+Because AAP associates the AAP Code with the checkout handoff, later outcome evidence can be checked against the signed payload, recommendation record, and allowed amount/status rules.
 
 ### Verification on Webhook
 
@@ -82,7 +82,7 @@ When AAP receives a payment webhook, it:
 2. Verifies the Ed25519 signature against the public key at `rako.sh/.well-known/jwks.json`.
 3. Decodes the payload and confirms the offer, merchant, and price match.
 4. Checks the payment amount matches the AAP Code price (within tolerance).
-5. Records the conversion as **verified** if all checks pass.
+5. Records the conversion state supported by the evidence if all applicable checks pass.
 
 ## Signing
 
@@ -181,21 +181,22 @@ Response (invalid):
 }
 ```
 
-## What the AAP Code Guarantees
+## What the AAP Code Asserts
 
 When a valid AAP Code is present:
 
-1. **The offer is real.** It was published by a verified merchant on the AAP registry.
-2. **The price is current.** It was accurate at the time of issuance.
-3. **The merchant is vetted.** They passed Rako's merchant verification.
-4. **The commission terms are immutable.** They were locked at issuance and cannot be altered retroactively.
-5. **The code is authentic.** Only Rako's private key could have produced the signature.
+1. **Rako issued the code.** The signature matches Rako's public key.
+2. **The payload was not changed after signing.** Any payload modification invalidates the signature.
+3. **The code refers to a registry offer.** The payload identifies the offer, merchant, price, currency, and commission terms as signed at issuance.
+4. **The code has an issuance and expiry time.** Consumers can check whether the code is still inside its validity window.
+5. **The code can be independently verified.** Builders and merchants can verify the signature without calling the API.
 
-## What the AAP Code Does NOT Guarantee
+## What the AAP Code Does NOT Assert
 
 1. **Real-time availability.** The offer may have sold out or expired since issuance. Check the `exp` field.
-2. **Price accuracy at checkout.** For live-pricing verticals (flights, hotels), the price may change. The AAP Code captures the price at discovery, not at checkout.
-3. **Conversion.** Having a code doesn't mean the user will buy.
+2. **Price accuracy at checkout.** For live-pricing verticals such as flights or hotels, the price may change. The AAP Code captures the price at discovery, not necessarily the checkout price.
+3. **Conversion.** Having a code does not mean the user will buy or that a conversion has occurred.
+4. **Commercial eligibility.** The code does not by itself prove that a user, merchant, or transaction qualifies for payout.
 
 ---
 

--- a/spec/v1/commission.md
+++ b/spec/v1/commission.md
@@ -103,10 +103,10 @@ Builders can challenge clawbacks through the dispute process with evidence from 
 Commission is settled monthly, after validation periods close for the relevant transactions.
 
 ### Payment Rails
-Settlement uses standard payment infrastructure:
-- Bank transfer (UK Faster Payments / SEPA)
-- Stripe Connect (for builders with Stripe accounts)
-- Agent-to-agent payment rails (Payman, Orthogonal) as they mature
+Settlement uses standard payout infrastructure, such as:
+- Bank transfer where available
+- Approved payout providers supported by Rako
+- Future agent-to-agent payout rails if they mature and pass compliance review
 
 ### Minimum Payout
 £25 minimum per settlement. Below threshold, balance carries forward to next period.

--- a/spec/v1/commission.md
+++ b/spec/v1/commission.md
@@ -102,11 +102,11 @@ Builders can challenge clawbacks through the dispute process with evidence from 
 ### Schedule
 Commission is settled monthly, after validation periods close for the relevant transactions.
 
-### Payment Rails
+### Builder payout methods
 Settlement uses standard payout infrastructure, such as:
 - Bank transfer where available
 - Approved payout providers supported by Rako
-- Future agent-to-agent payout rails if they mature and pass compliance review
+- Future builder payout methods if they mature and pass agreement and compliance review
 
 ### Minimum Payout
 £25 minimum per settlement. Below threshold, balance carries forward to next period.

--- a/spec/v1/commission.md
+++ b/spec/v1/commission.md
@@ -32,7 +32,7 @@ Floors are reviewed quarterly and adjusted based on:
 
 ## Network Fee
 
-AAP takes a 20% network fee on every commission paid out.
+AAP's standard illustrative model uses a 20% network fee on commission paid out. Actual commercial terms are subject to the applicable merchant, builder, and Rako agreement.
 
 ```
 Gross commission (merchant pays)
@@ -45,18 +45,18 @@ Example:
   AAP receives: £1.60
 ```
 
-The network fee is non-negotiable for standard tiers. Enterprise merchants (post-2028) may negotiate volume-based discounts (15-18%).
+Network-fee schedules may vary by agreement, tier, or future commercial programme. Do not treat the examples in this public specification as a binding offer or final statement of commercial terms.
 
 ## Commission by Conversion Path
 
 Different conversion paths earn different commission rates:
 
-| Path | Rate | Example (£8 CPA) |
+| Path | Rate | Example under illustrative 20% network-fee model (£8 CPA) |
 |------|------|-------------------|
-| **AAP flow** (direct) | 100% of merchant rate | £8.00 → £6.40 builder, £1.60 AAP |
-| **Tracked link** | 75% of merchant rate | £6.00 → £4.80 builder, £1.20 AAP |
-| **Browser extension** | 75% of merchant rate | £6.00 → £4.80 builder, £1.20 AAP |
-| **Influence attribution** | 50% of merchant rate | £4.00 → £3.20 builder, £0.80 AAP |
+| **AAP flow** (direct) | 100% of merchant rate where supported by agreement | £8.00 → £6.40 builder, £1.60 AAP |
+| **Tracked link** | 75% of merchant rate where supported by agreement | £6.00 → £4.80 builder, £1.20 AAP |
+| **Browser extension** | 75% of merchant rate where supported by agreement | £6.00 → £4.80 builder, £1.20 AAP |
+| **Influence attribution** | 50% of merchant rate or flat fee where supported by agreement | £4.00 → £3.20 builder, £0.80 AAP |
 
 The reduced rates for non-direct paths reflect:
 - Lower certainty of attribution
@@ -121,7 +121,7 @@ Commission value: £8.00
 Conversion path: AAP flow (100%)
 
 Commission: £8.00
-Network fee (20%): £1.60
+Network fee (illustrative 20%): £1.60
 Builder payout: £6.40
 ```
 
@@ -134,7 +134,7 @@ Transaction value: £189.00
 Conversion path: AAP flow (100%)
 
 Commission: £189 × 0.05 = £9.45
-Network fee (20%): £1.89
+Network fee (illustrative 20%): £1.89
 Builder payout: £7.56
 ```
 
@@ -149,7 +149,7 @@ Conversion path: Tracked link (75%)
 
 Base commission: £15.00 + (£487.32 × 0.03) = £29.62
 Tracked link rate: £29.62 × 0.75 = £22.22
-Network fee (20%): £4.44
+Network fee (illustrative 20%): £4.44
 Builder payout: £17.78
 ```
 

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -1,10 +1,10 @@
 # Payment Architecture
 
-> How AAP verifies purchases trustlessly without processing payments.
+> How AAP records checkout handoffs and reconciles purchase outcome evidence without processing payments.
 
 ## Core Principle
 
-AAP does not process payments. AAP orchestrates payments on the merchant's own payment processor via Hyperswitch. The merchant pays the same processor fees they'd pay on their own website. Commission is invoiced separately to the merchant as a B2B receivable.
+AAP does not process payments, collect payment credentials, hold funds, or move money. AAP can create or return hosted checkout links through payment orchestration controlled by the platform and merchant configuration. The user completes checkout with the merchant or the merchant's payment provider. Commission is accounted for separately as a merchant-to-AAP receivable, not as a deduction from user payment funds.
 
 ---
 
@@ -12,116 +12,113 @@ AAP does not process payments. AAP orchestrates payments on the merchant's own p
 
 ### Mode 1 — User Checkout (Default)
 
-The agent recommends. The user completes checkout.
+The agent recommends an offer. The user chooses whether to open a hosted checkout link and complete checkout.
 
-```
-Agent → POST /v1/purchase { recommendationId }
-  ← { checkoutUrl, paymentId }
+```text
+Agent → POST /v1/checkout { recommendationId }
+  ← { checkoutUrl, transactionId, status }
 
-User → opens checkoutUrl (Hyperswitch payment link)
-  → enters card on merchant's PSP-hosted checkout
-  → payment settles to merchant via merchant's PSP
+User → opens checkoutUrl
+  → reviews merchant checkout
+  → enters payment credentials with the merchant or payment provider
+  → payment settles to the merchant through the merchant's payment setup
 
-Hyperswitch → webhook to AAP
-  → AAP records verified conversion
+Payment outcome event or merchant report → AAP
+  → AAP reconciles conversion evidence
 ```
 
 **Flow:**
-1. Agent calls `POST /v1/purchase` with the `recommendationId` from a prior recommendation.
-2. AAP creates a Hyperswitch payment link on the merchant's connected processor.
-3. AAP embeds the AAP Code in the payment's `metadata.aap_code` field.
+1. Agent calls `POST /v1/checkout` with the `recommendationId` from a prior recommendation.
+2. AAP creates or returns a hosted checkout link for the selected offer.
+3. AAP records the AAP Code and recommendation identifiers in platform-side attribution context where supported by the checkout path.
 4. The checkout URL is returned to the agent, which presents it to the user.
-5. The user enters payment credentials directly into the PSP-hosted checkout.
-6. Payment settles from buyer → merchant's PSP → merchant. AAP never touches funds.
-7. Hyperswitch fires a webhook to AAP confirming the payment outcome.
-8. AAP records the conversion as **verified** (trustless — confirmed by neutral PSP).
+5. The user enters payment credentials directly with the merchant or payment provider.
+6. Payment settles from buyer to merchant. AAP does not touch funds.
+7. A payment outcome event or merchant conversion report is reconciled against the recommendation and AAP Code.
+8. AAP records the conversion state according to the evidence available and validation checks that pass.
 
-### Mode 2 — Agent Autonomous
+### Mode 2 — Agent-Assisted Checkout (Future)
 
-The agent has stored payment credentials and completes the purchase without user interaction.
+Some agent-commerce flows may eventually support user-authorised stored payment credentials. This mode is not required for the v1 developer flow.
 
+```text
+Agent → POST /v1/checkout { recommendationId, user-authorised payment reference }
+  ← { transactionId, status }
+
+Payment outcome event or merchant report → AAP
+  → AAP reconciles conversion evidence
 ```
-Agent → POST /v1/purchase { recommendationId, paymentMethod }
-  ← { confirmation, paymentId, status }
 
-Hyperswitch → processes via merchant's PSP
-  → webhook to AAP
-  → AAP records verified conversion
-```
-
-**Flow:**
-1. Agent calls `POST /v1/purchase` with `recommendationId` and a `paymentMethod` (tokenised card, stored credential).
-2. AAP creates a Hyperswitch payment intent and processes it directly.
-3. AAP Code is embedded in payment metadata.
-4. Payment settles to merchant via merchant's PSP. AAP never touches funds.
-5. Webhook confirms outcome. Conversion recorded as verified.
-
-**Note:** Mode 2 requires the agent to have legitimate stored payment credentials from the user. AAP does not vault or manage user payment credentials.
+**Note:** Any agent-assisted payment flow requires explicit user authorisation and compliant credential handling by the relevant payment provider. AAP does not vault or manage user payment credentials.
 
 ---
 
 ## Verification Model
 
-### Why Trustless Verification Matters
+### Why Outcome Evidence Matters
 
-Every party in the transaction has an incentive to misreport:
+Every party in the transaction has a different incentive:
 
 | Party | Incentive |
 |-------|-----------|
-| Agent | Wants commission — could fabricate conversions |
-| Merchant | Wants to avoid commission — could deny conversions |
-| Merchant's PSP | No stake in AAP's commission — neutral third party |
+| Agent | Wants commission and may over-claim conversions |
+| Merchant | Wants accurate commission liability and may dispute conversions |
+| Payment outcome source | Provides transaction status, amount, and attribution metadata where available |
 
-AAP trusts the PSP. The PSP reports what happened: payment created, succeeded or failed, amount and metadata. This is the same trust model as a bank statement.
+AAP reconciles conversion evidence from the available sources. Evidence may include authenticated payment outcome events, merchant conversion reports, recommendation records, AAP Code validation, amount matching, status checks, and validation-period results.
 
 ### Verification Levels
 
-| Level | Source | Trust | Commission Rate | Settlement Speed |
-|-------|--------|-------|-----------------|------------------|
-| **Verified** | Hyperswitch PSP webhook | Trustless — neutral third party confirms payment | Full commission | Standard (after validation period) |
-| **Unverified** | Agent callback or merchant self-report | Trust-dependent — requires validation period | Reduced commission (75%) | Delayed (extended validation period) |
+| Level | Source | Evidence Basis | Commission Rate | Settlement Speed |
+|-------|--------|----------------|-----------------|------------------|
+| **Payment-observed** | Authenticated payment outcome event | Payment status, amount, attribution context, and AAP Code checks match | Full commission where merchant terms allow | Standard after validation period |
+| **Merchant-reported** | Merchant conversion report | Merchant report plus recommendation/session matching | Merchant terms, usually after validation checks | Standard or delayed by validation policy |
+| **Fallback-reported** | Agent callback, tracked link, or other fallback evidence | Lower-confidence attribution evidence requiring additional validation | Reduced commission where supported | Delayed by extended validation policy |
 
-**Verified conversions** are confirmed by the merchant's payment processor via Hyperswitch webhook. The processor has no relationship with AAP and no reason to fabricate or hide transactions.
+**Payment-observed conversions** are recorded when authenticated payment outcome evidence can be matched to the recommendation and AAP Code checks pass.
 
-**Unverified conversions** occur when the purchase happens outside AAP's orchestration (e.g., tracked link fallback). These rely on agent callbacks or merchant reporting and carry a longer validation period and reduced commission.
+**Merchant-reported conversions** are recorded when the merchant reports a completed sale and the report matches a known recommendation/session.
+
+**Fallback-reported conversions** occur when the purchase happens outside the hosted checkout handoff, such as through a tracked link fallback. These rely on lower-confidence evidence and may carry a longer validation period or reduced commission.
 
 ---
 
 ## Fee Structure
 
-AAP introduces **zero additional payment processing fees**.
+AAP introduces **no additional card processing fee charged by AAP**.
 
 | Fee | Who Pays | To Whom |
 |-----|----------|---------|
-| PSP processing fee (e.g., 1.4% + 20p) | Merchant | Merchant's PSP (Stripe, Adyen, etc.) |
-| AAP commission (e.g., £8 CPA) | Merchant | AAP (invoiced monthly as B2B receivable) |
-| AAP network fee (20% of commission) | Deducted from commission | AAP retains; remainder to Agent Builder |
+| Payment processing fee | Merchant | Merchant's payment provider |
+| AAP commission | Merchant | AAP, invoiced or otherwise accounted for as a B2B receivable |
+| AAP network fee | Deducted from commission | AAP retains the network fee; the remainder is payable to the agent builder |
 
-The merchant pays exactly the same PSP fees they'd pay without AAP. Commission is a separate invoice, not a deduction from payment funds.
-
----
-
-## Merchant Onboarding (OAuth)
-
-Merchants connect their existing PSP account to AAP via OAuth:
-
-1. Merchant clicks **"Connect your Stripe"** on the AAP dashboard.
-2. OAuth flow redirects to Stripe (or Adyen, Worldpay, etc.).
-3. Merchant authorises scoped access (minimum required permissions).
-4. AAP stores the access token as a Hyperswitch connector.
-5. AAP can now create payment links and receive webhooks on the merchant's account.
-
-**Scope restrictions (ENG-08):**
-- Read payment intents and payment methods
-- Create payment links / checkout sessions
-- Receive webhooks
-- **Excluded:** payouts, transfers, balance reads, bank account access
+The merchant's payment processing fees are separate from AAP commission. Commission is not deducted from user payment funds by the protocol.
 
 ---
 
-## AAP Code in Payment Metadata
+## Merchant Payment Configuration
 
-Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
+Merchants configure the payment or checkout path that AAP may use for hosted checkout handoffs. The exact onboarding method depends on the merchant's payment setup and Rako's supported connectors.
+
+Typical configuration includes:
+
+1. Merchant selects an approved checkout/payment connection in the AAP dashboard.
+2. Merchant authorises the minimum required permissions for checkout creation and outcome events.
+3. AAP stores the connection configuration securely.
+4. AAP can create or return hosted checkout links and reconcile outcome events for the merchant's account.
+
+**Scope restrictions:**
+- Create checkout links or payment intents where supported
+- Read payment status and attribution metadata needed for reconciliation
+- Receive payment outcome events
+- **Excluded:** payouts, transfers, balance reads, bank account access, and unrelated merchant account administration
+
+---
+
+## AAP Code in Attribution Context
+
+AAP-controlled checkout paths should associate the AAP Code with the platform-side attribution context:
 
 ```json
 {
@@ -133,31 +130,30 @@ Every AAP-orchestrated payment embeds the AAP Code in the PSP's metadata:
 }
 ```
 
-This is set by AAP when creating the payment via Hyperswitch — not by the agent. The agent cannot modify or forge payment metadata. The PSP stores it alongside the payment record, creating a tamper-proof attribution link.
+This context is set by AAP or its payment orchestration layer when the checkout object is created. Agents do not set payment metadata themselves.
 
-On webhook receipt, AAP verifies:
-1. The `aap_code` signature is valid (Ed25519 verification).
+On outcome receipt, AAP checks:
+1. The `aap_code` signature is valid using Ed25519 verification.
 2. The `aap_code` payload matches the recommendation and offer.
-3. The payment amount matches the offer price (within tolerance).
-4. The payment status is `succeeded`.
+3. The reported amount matches the offer price within allowed tolerance.
+4. The payment or merchant-reported status indicates a completed transaction.
+5. The event source and payload pass the applicable authentication and reconciliation checks.
 
-If all checks pass, the conversion is recorded as **verified**.
+If the applicable checks pass, AAP records the conversion state supported by that evidence.
 
 ---
 
-## Hyperswitch's Role
+## Payment Orchestration Role
 
-Hyperswitch is an open-source payment switch. It is **not** a payment processor.
+AAP's payment orchestration layer provides a neutral abstraction over merchant checkout and payment-provider differences. It may provide:
 
-- Does not hold money
-- Does not move money
-- Does not compete with Stripe, Adyen, or Worldpay
+- Hosted checkout link creation
+- Payment outcome event normalization
+- Connector configuration for supported merchant payment setups
+- Attribution metadata attachment where supported
+- Reconciliation inputs for conversion matching
 
-Hyperswitch provides:
-- **One API** for AAP to create payments across 275+ processors
-- **Payment links** — hosted checkout pages
-- **Webhooks** — unified event format regardless of underlying processor
-- **Connector framework** — merchant connects their PSP once, AAP uses it for all transactions
+The protocol does not require public implementers to depend on a named payment vendor. Public integrations should describe this layer generically as payment orchestration, hosted checkout, payment provider, or outcome-event reconciliation.
 
 ---
 

--- a/spec/v1/payments.md
+++ b/spec/v1/payments.md
@@ -145,7 +145,7 @@ If the applicable checks pass, AAP records the conversion state supported by tha
 
 ## Payment Orchestration Role
 
-AAP's payment orchestration layer provides a neutral abstraction over merchant checkout and payment-provider differences. It may provide:
+AAP's payment orchestration layer provides a common abstraction over merchant checkout and payment-provider differences. It may provide:
 
 - Hosted checkout link creation
 - Payment outcome event normalization

--- a/spec/v1/security.md
+++ b/spec/v1/security.md
@@ -65,7 +65,7 @@ This creates a tamper-evident audit trail. Modifying any event breaks the chain 
 
 ### Open Spec, Centralised Trust
 
-AAP uses the same trust model as DNS, Visa, and Stripe:
+AAP uses a centralised registry, verification, and settlement trust model:
 
 | Layer | Open or Centralised |
 |-------|-------------------|
@@ -99,9 +99,9 @@ The same question comes up every time someone builds a trust layer. The answer f
 - **Speed:** Agent transactions happen in milliseconds. Block confirmation takes seconds to minutes.
 - **Cost:** Per-transaction on-chain fees eat into commissions.
 - **Privacy:** On-chain data is visible. Merchant and builder data must be siloed.
-- **Equivalent guarantee:** Hash-chained signed logs provide the same tamper-evidence without distributed consensus overhead.
+- **Tamper-evidence without consensus:** Hash-chained signed logs provide audit evidence without distributed consensus overhead.
 
-The trust comes from cryptography, not consensus. Ed25519 signatures are just as unforgeable whether they're stored in a database or on a blockchain.
+The trust model relies on cryptographic signing and controlled verification rather than public consensus. Ed25519 signatures remain verifiable whether the signed records are stored in a private database or on a public ledger.
 
 ## API Security
 
@@ -119,7 +119,7 @@ The trust comes from cryptography, not consensus. Ed25519 signatures are just as
 ### Rate Limiting
 - Per-key rate limits prevent abuse
 - Graduated response: slow down → temporary block → review
-- DDoS protection via Cloudflare
+- DDoS protection at the network edge
 
 ---
 

--- a/spec/v1/security.md
+++ b/spec/v1/security.md
@@ -72,7 +72,7 @@ AAP uses a centralised registry, verification, and settlement trust model:
 | The specification | **Open** — anyone can read and implement |
 | AAP Code issuance | **Centralised** — only Rako issues valid codes |
 | Verification | **Centralised** — Rako verifies conversions |
-| Settlement | **Centralised** — Rako settles commission |
+| Settlement | **Centralised** — Rako administers commission settlement according to applicable terms |
 | Fraud detection | **Closed** — proprietary models and rules |
 
 ### What Each Party Can Verify


### PR DESCRIPTION
Refs #6

## Summary
- Removed named internal/payment vendors from public spec payment, security, commission, and AAP Code wording.
- Replaced trustless/tamper-proof/guarantee framing with neutral checkout handoff, payment orchestration, outcome-event reconciliation, and signed-payload assertions.
- Updated the payment architecture nav description to avoid vendor-specific integration language.
- Corrected public legal-entity wording to RAKO HQ LTD / Company No. 17132612 and narrowed the trademark notice to application/status-check wording.
- Marked the 20% network-fee examples as illustrative/subject to applicable agreements, and removed non-negotiable/future enterprise commercial claims.
- Corrected the README Python import to `agent_attribution_protocol`.

## Compatibility notes
- No protocol field names or endpoint schemas changed.
- The AAP Code metadata example remains structurally unchanged; only surrounding public explanatory wording changed.
- Public implementers should describe payment dependencies generically as payment orchestration, hosted checkout, payment provider, or outcome-event reconciliation.
- Public commercial examples should be described as illustrative unless they are backed by current agreement terms or approval scope.
- Public trademark/legal-entity notices should avoid implying registration or final owner status beyond current evidence.

## Implementation impact
- Backend/SDK behavior is unchanged.
- Developer docs can continue to reference the existing public spec paths without link changes.
- This PR is a wording/guardrail fix only; no package release, publishing, deployment, or sensitive public claim action is included.

## Verification
- `git diff origin/main --check` → ok
- Markdown relative link scan: `missing_links []`
- Public vendor guardrail scan: clean for `Hyperswitch|Stripe|Adyen|Worldpay|Visa|Cloudflare|Payman|Orthogonal`
- Sensitive/legal/commercial guardrail scan: clean for `trustless|tamper-proof|guarantee|guarantees|production-ready|ready for production|readiness|vetted|neutral third party|non-negotiable|post-2028|Rako Ltd|Rako settles commission|Verifies merchants|trademark of Rako`
- Acceptance spot-checks: `python_import=True`, `legal_entity_footer=True`, `trademark_application=True`, `commission_subject_to_agreement=True`

## Deployment / follow-up
- Do not publish or release from this PR.
- After merge, rerun developer onboarding public surface scans before developer activation.



## Legal rereview follow-up (2026-05-01)
- Reframed `spec/v1/aap-code.md` `Verification on Webhook` as required/intended production payment-outcome verification behavior, explicitly not a claim that every current checkout or webhook path already performs those checks live.
- Renamed `spec/v1/commission.md` `Payment Rails` to `Builder payout methods` and kept future payout methods agreement/compliance-review gated.
- Follow-up commit: `9ea14d6`.

### Follow-up verification
- `git diff origin/main --check` → ok
- Sensitive/vendor scan for named payment vendors, payment-rail phrasing, production/live guarantees, and stale commercial/legal phrases → clean
- Targeted rereview checks passed: old webhook live-claim absent; required behavior qualifier present; `Payment Rails` heading absent; `Builder payout methods` heading present; agreement/compliance gate present.
